### PR TITLE
Create static Golgotha film marketing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Golgotha-Website
+# Golgotha Website
+
+Static marketing site for the feature film **Golgotha**, a poetic horror-noir about Detective David Hill confronting grief, faith, and supernatural crime. The site is optimized to cultivate financing conversations, audience signups, and supporter donations.
+
+## Structure
+
+- `index.html` &mdash; Homepage hero, KPIs, and momentum overview.
+- `story.html` &mdash; Three-act synopsis.
+- `director.html` &mdash; Director's statement.
+- `cast-crew.html` &mdash; Placeholder cast and crew bios.
+- `gallery.html` &mdash; Mood still placeholders.
+- `press.html` &mdash; Press status.
+- `screenings.html` &mdash; Screening updates.
+- `investors.html` &mdash; Financing overview, KPIs, and CTAs.
+- `contact.html` &mdash; Contact form and production office details.
+- `assets/css/main.css` &mdash; Shared noir-inspired styling.
+- `public/poster-og-placeholder.svg` &mdash; Text-based poster placeholder used for open graph metadata.
+
+## Local Preview
+
+Open any of the HTML files directly in a browser or serve the directory with a simple HTTP server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000/`.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,20 +1,28 @@
 :root {
-  --bg-primary: #0b0b0b;
+  --bg-primary: #050505;
+  --bg-secondary: #0b0b0b;
+  --bg-elevated: rgba(233, 230, 223, 0.03);
+  --bg-contrast: rgba(139, 15, 15, 0.08);
   --text-primary: #e9e6df;
-  --text-muted: rgba(233, 230, 223, 0.72);
+  --text-muted: rgba(233, 230, 223, 0.65);
   --accent: #8b0f0f;
+  --accent-hot: #c51f1f;
   --accent-soft: rgba(139, 15, 15, 0.35);
-  --max-width: 1080px;
+  --accent-glow: rgba(197, 31, 31, 0.4);
+  --max-width: 1120px;
   --font-heading: "Archivo Condensed", "Impact", "Haettenschweiler", "Arial Narrow", sans-serif;
   --font-body: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-mono: "IBM Plex Mono", "SFMono-Regular", "Consolas", monospace;
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
   background: var(--bg-primary);
@@ -34,63 +42,101 @@ body {
 body::before {
   content: "";
   position: fixed;
-  inset: -200px;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(197, 31, 31, 0.16), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(104, 12, 12, 0.24), transparent 60%),
+    radial-gradient(circle at 50% 80%, rgba(197, 31, 31, 0.12), transparent 50%);
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.25'/%3E%3C/svg%3E");
-  mix-blend-mode: screen;
-  opacity: 0.16;
-  animation: grain 12s steps(10) infinite;
+  opacity: 0.9;
   z-index: 0;
 }
 
+body::after {
+  content: "";
+  position: fixed;
+  inset: -200px;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.1' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.22'/%3E%3C/svg%3E");
+  mix-blend-mode: screen;
+  animation: grain 14s steps(10) infinite;
+  z-index: 1;
+  opacity: 0.18;
+}
+
 @keyframes grain {
-  0% { transform: translate3d(0, 0, 0); }
-  100% { transform: translate3d(-10px, 10px, 0); }
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(-10px, 10px, 0);
+  }
 }
 
 header {
   position: sticky;
   top: 0;
-  z-index: 10;
-  background: rgba(11, 11, 11, 0.92);
-  backdrop-filter: blur(6px);
+  z-index: 20;
+  backdrop-filter: blur(12px);
+  background: rgba(5, 5, 5, 0.92);
   border-bottom: 1px solid rgba(233, 230, 223, 0.08);
+}
+
+header::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -1px 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(197, 31, 31, 0.6), transparent);
 }
 
 .nav-container {
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: 1.25rem 1.5rem;
+  padding: 1.35rem 1.75rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .brand {
   font-family: var(--font-heading);
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 1.25rem;
+  letter-spacing: 0.22em;
+  font-size: 1.35rem;
   color: var(--text-primary);
   text-decoration: none;
+  position: relative;
+}
+
+.brand::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.3rem;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent-hot), transparent);
+  opacity: 0.6;
 }
 
 nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem 1.25rem;
+  gap: 0.65rem 1.5rem;
+  justify-content: flex-end;
 }
 
 nav a {
   font-family: var(--font-heading);
   text-transform: uppercase;
-  letter-spacing: 0.14em;
-  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  font-size: 0.74rem;
   color: var(--text-muted);
   text-decoration: none;
   position: relative;
-  padding-bottom: 0.25rem;
+  padding-bottom: 0.35rem;
+  transition: color 180ms ease;
 }
 
 nav a::after {
@@ -100,10 +146,10 @@ nav a::after {
   bottom: 0;
   width: 100%;
   height: 2px;
-  background: transparent;
+  background: linear-gradient(90deg, transparent, var(--accent-hot));
   transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 180ms ease, background 180ms ease;
+  transform-origin: right;
+  transition: transform 200ms ease;
 }
 
 nav a:hover,
@@ -114,63 +160,111 @@ nav a:focus {
 nav a:hover::after,
 nav a:focus::after,
 nav a[aria-current="page"]::after {
-  background: var(--accent);
   transform: scaleX(1);
+  transform-origin: left;
 }
 
 main {
   flex: 1;
+  position: relative;
+  z-index: 2;
 }
 
 .section {
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: 4rem 1.5rem;
+  padding: 5rem 1.75rem;
   position: relative;
-  z-index: 1;
 }
 
-.section.hero {
-  display: grid;
-  gap: 1.5rem;
+.section::before {
+  content: "";
+  position: absolute;
+  inset: 1.5rem;
+  border: 1px solid rgba(233, 230, 223, 0.05);
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.section:hover::before {
+  opacity: 1;
+}
+
+.section--contrast {
+  background: linear-gradient(135deg, rgba(139, 15, 15, 0.08), rgba(5, 5, 5, 0.65));
+  border-radius: 20px;
+  padding: 5rem clamp(1.5rem, 6vw, 4rem);
+  overflow: hidden;
+}
+
+.section--overlay {
+  background: rgba(11, 11, 11, 0.7);
+  border-radius: 20px;
+  backdrop-filter: blur(6px);
+  padding: 5rem clamp(1.5rem, 6vw, 4rem);
+}
+
+.section--tight {
+  padding-top: 3.5rem;
+  padding-bottom: 3.5rem;
 }
 
 .overline {
   font-family: var(--font-mono);
   text-transform: uppercase;
-  letter-spacing: 0.28em;
-  font-size: 0.75rem;
+  letter-spacing: 0.32em;
+  font-size: 0.72rem;
   color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
-h1, h2, h3, h4 {
+.overline::before {
+  content: "";
+  width: 32px;
+  height: 1px;
+  background: linear-gradient(90deg, var(--accent-hot), transparent);
+}
+
+h1,
+h2,
+h3,
+h4 {
   font-family: var(--font-heading);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.75rem;
   color: var(--text-primary);
 }
 
 h1 {
-  font-size: clamp(2.5rem, 5vw, 4.5rem);
-  line-height: 1.05;
+  font-size: clamp(3rem, 7vw, 5rem);
+  line-height: 1.02;
+}
+
+h2 {
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1.1;
 }
 
 p {
-  line-height: 1.6;
-  max-width: 72ch;
+  line-height: 1.7;
+  max-width: 76ch;
+  color: rgba(233, 230, 223, 0.9);
 }
 
 p.caption {
   font-family: var(--font-mono);
   text-transform: uppercase;
-  letter-spacing: 0.2em;
-  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  font-size: 0.68rem;
   color: var(--text-muted);
 }
 
 a {
-  color: var(--accent);
+  color: var(--accent-hot);
 }
 
 a.button,
@@ -178,169 +272,60 @@ button.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.9rem 1.4rem;
-  border: 1px solid var(--accent);
+  gap: 0.65rem;
+  padding: 0.95rem 1.6rem;
+  border: 1px solid rgba(197, 31, 31, 0.6);
   color: var(--text-primary);
   text-decoration: none;
   text-transform: uppercase;
   font-family: var(--font-heading);
-  letter-spacing: 0.2em;
-  background: rgba(139, 15, 15, 0.1);
-  transition: background 160ms ease, transform 160ms ease, box-shadow 160ms ease;
-}
-
-a.button:hover,
-button.button:hover {
-  background: var(--accent);
-  transform: translateY(-2px);
-  box-shadow: 0 10px 25px rgba(139, 15, 15, 0.35);
-}
-
-.grid {
-  display: grid;
-  gap: 2rem;
-}
-
-.two-column {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  align-items: start;
-}
-
-.cards {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.card {
-  border: 1px solid rgba(233, 230, 223, 0.12);
-  padding: 1.5rem;
-  background: rgba(233, 230, 223, 0.02);
+  letter-spacing: 0.24em;
+  background: linear-gradient(135deg, rgba(139, 15, 15, 0.75), rgba(139, 15, 15, 0.35));
+  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+  border-radius: 999px;
   position: relative;
   overflow: hidden;
 }
 
-.card::before {
+a.button::after,
+button.button::after {
   content: "";
   position: absolute;
   inset: 0;
-  border: 1px solid rgba(139, 15, 15, 0.2);
+  background: linear-gradient(120deg, rgba(233, 230, 223, 0.12), transparent 55%);
   opacity: 0;
   transition: opacity 200ms ease;
 }
 
-.card:hover::before {
+a.button:hover,
+button.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(197, 31, 31, 0.3);
+}
+
+a.button:hover::after,
+button.button:hover::after {
   opacity: 1;
 }
 
-.card h3 {
-  margin-top: 0.5rem;
+.hero {
+  display: grid;
+  gap: clamp(2.5rem, 6vw, 4.5rem);
+  grid-template-columns: minmax(280px, 1.35fr) minmax(220px, 1fr);
+  align-items: stretch;
+  min-height: calc(100vh - 140px);
 }
 
-.headshot {
-  width: 100%;
-  aspect-ratio: 3 / 4;
-  border: 1px solid rgba(233, 230, 223, 0.12);
-  background: linear-gradient(135deg, rgba(233, 230, 223, 0.08), rgba(233, 230, 223, 0));
-  display: grid;
-  place-items: center;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  letter-spacing: 0.2em;
-  color: var(--text-muted);
-  text-transform: uppercase;
-}
-
-.gallery-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+.hero-content {
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
-}
-
-.gallery-item {
-  border: 1px solid rgba(233, 230, 223, 0.12);
-  padding: 1rem;
-  background: rgba(233, 230, 223, 0.02);
-  min-height: 200px;
-  display: flex;
-  flex-direction: column;
   justify-content: center;
-  align-items: center;
-  text-align: center;
 }
 
-.gallery-item span {
-  font-family: var(--font-mono);
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 2rem;
-}
-
-.table th,
-.table td {
-  border: 1px solid rgba(233, 230, 223, 0.12);
-  padding: 1rem;
-  text-align: left;
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 1.5rem;
-}
-
-input, textarea {
-  background: rgba(233, 230, 223, 0.05);
-  border: 1px solid rgba(233, 230, 223, 0.18);
-  padding: 0.9rem 1rem;
-  color: var(--text-primary);
-  font-family: var(--font-body);
-  border-radius: 2px;
-}
-
-input:focus,
-textarea:focus {
-  outline: 1px solid var(--accent);
-  outline-offset: 0;
-}
-
-footer {
-  border-top: 1px solid rgba(233, 230, 223, 0.08);
-  padding: 2rem 1.5rem;
-  text-align: center;
-  font-family: var(--font-mono);
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}
-
-footer .container {
-  max-width: var(--max-width);
-  margin: 0 auto;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid rgba(233, 230, 223, 0.18);
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-}
-
-.section + .section {
-  border-top: 1px solid rgba(233, 230, 223, 0.08);
+.hero-lede {
+  font-size: 1.05rem;
+  color: rgba(233, 230, 223, 0.85);
 }
 
 .hero-actions {
@@ -349,11 +334,406 @@ footer .container {
   gap: 1rem;
 }
 
-blockquote {
-  border-left: 2px solid var(--accent);
-  padding-left: 1rem;
-  font-style: italic;
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.62rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(233, 230, 223, 0.18);
   color: var(--text-muted);
+}
+
+.badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-hot);
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+
+.badge--glow {
+  background: rgba(197, 31, 31, 0.14);
+  border-color: rgba(197, 31, 31, 0.6);
+  color: var(--text-primary);
+}
+
+.badge--outline {
+  background: transparent;
+  border-style: dashed;
+}
+
+.hero-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+}
+
+.hero-media {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px solid rgba(233, 230, 223, 0.1);
+  border-radius: 20px;
+  background: linear-gradient(160deg, rgba(139, 15, 15, 0.4), rgba(5, 5, 5, 0.85));
+  overflow: hidden;
+}
+
+.hero-media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 20%, rgba(233, 230, 223, 0.08), transparent 60%);
+  pointer-events: none;
+}
+
+.hero-frame {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  border-radius: 14px;
+  padding: 1.5rem;
+  background: rgba(5, 5, 5, 0.6);
+  margin-bottom: 1.5rem;
+}
+
+.hero-poster {
+  width: 100%;
+  aspect-ratio: 3 / 4.4;
+  border: 1px solid rgba(233, 230, 223, 0.18);
+  border-radius: 12px;
+  background: repeating-linear-gradient(135deg, rgba(233, 230, 223, 0.08) 0 12px, rgba(233, 230, 223, 0.02) 12px 24px);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 1.2rem;
+}
+
+.hero-poster span {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.72rem;
+  color: rgba(233, 230, 223, 0.6);
+}
+
+.grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.two-column {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.cards {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  position: relative;
+  border: 1px solid rgba(233, 230, 223, 0.08);
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+  background: linear-gradient(150deg, rgba(233, 230, 223, 0.06), rgba(5, 5, 5, 0.7));
+  border-radius: 18px;
+  overflow: hidden;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border: 1px solid rgba(197, 31, 31, 0.18);
+  border-radius: 16px;
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 30%, rgba(197, 31, 31, 0.18));
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 16px 45px rgba(197, 31, 31, 0.18);
+}
+
+.card:hover::before,
+.card:hover::after {
+  opacity: 1;
+}
+
+.card h3 {
+  margin-top: 0.8rem;
+}
+
+blockquote {
+  margin: 0;
+  padding: 2.2rem 2.4rem;
+  border-left: 2px solid var(--accent-hot);
+  background: rgba(139, 15, 15, 0.08);
+  border-radius: 16px;
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.headshot {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(233, 230, 223, 0.08), rgba(233, 230, 223, 0.02));
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.24em;
+  color: rgba(233, 230, 223, 0.6);
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+}
+
+.gallery-item {
+  border: 1px solid rgba(233, 230, 223, 0.1);
+  border-radius: 16px;
+  padding: 1.6rem;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background: linear-gradient(150deg, rgba(233, 230, 223, 0.05), rgba(5, 5, 5, 0.75));
+  position: relative;
+  overflow: hidden;
+}
+
+.gallery-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 35%, rgba(197, 31, 31, 0.22));
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.gallery-item:hover::after {
+  opacity: 1;
+}
+
+.gallery-item span {
+  font-family: var(--font-mono);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: rgba(233, 230, 223, 0.6);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 2.5rem;
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid rgba(233, 230, 223, 0.08);
+  padding: 1.25rem 1.5rem;
+  text-align: left;
+  background: rgba(11, 11, 11, 0.8);
+}
+
+.table th {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.8rem;
+  background: rgba(139, 15, 15, 0.22);
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1.8rem;
+}
+
+label {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+input,
+textarea {
+  background: rgba(233, 230, 223, 0.06);
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  padding: 1rem 1.1rem;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  border-radius: 12px;
+  transition: border 180ms ease, box-shadow 180ms ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(197, 31, 31, 0.8);
+  box-shadow: 0 0 0 3px rgba(197, 31, 31, 0.18);
+}
+
+textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.page-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(2rem, 5vw, 3.5rem);
+  align-items: end;
+  padding-bottom: 4rem;
+  border-bottom: 1px solid rgba(233, 230, 223, 0.08);
+}
+
+.page-hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-hero__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.list-soft {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.list-soft li {
+  position: relative;
+  padding-left: 1.5rem;
+  color: rgba(233, 230, 223, 0.88);
+}
+
+.list-soft li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-hot);
+  box-shadow: 0 0 12px rgba(197, 31, 31, 0.5);
+}
+
+.status-panel {
+  border: 1px solid rgba(233, 230, 223, 0.08);
+  border-radius: 18px;
+  padding: 1.8rem;
+  background: rgba(5, 5, 5, 0.78);
+  display: grid;
+  gap: 0.8rem;
+}
+
+.status-panel strong {
+  font-family: var(--font-heading);
+  letter-spacing: 0.14em;
+}
+
+.address-block {
+  font-family: var(--font-mono);
+  letter-spacing: 0.18em;
+  font-size: 0.68rem;
+  color: rgba(233, 230, 223, 0.72);
+  line-height: 1.8;
+  text-transform: uppercase;
+}
+
+footer {
+  border-top: 1px solid rgba(233, 230, 223, 0.08);
+  padding: 2.75rem 1.5rem;
+  text-align: center;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: rgba(233, 230, 223, 0.6);
+  position: relative;
+}
+
+footer::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 140px;
+  height: 1px;
+  transform: translateX(-50%);
+  background: linear-gradient(90deg, transparent, rgba(197, 31, 31, 0.7), transparent);
+}
+
+@media (max-width: 960px) {
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: unset;
+  }
+
+  .hero-media {
+    order: -1;
+  }
+
+  .section::before {
+    inset: 1rem;
+  }
 }
 
 @media (max-width: 640px) {
@@ -364,24 +744,23 @@ blockquote {
 
   nav {
     width: 100%;
+    justify-content: flex-start;
   }
 
-  nav a {
-    font-size: 0.65rem;
+  .section {
+    padding: 4rem 1.25rem;
   }
 
-  .hero-actions {
-    flex-direction: column;
-    align-items: stretch;
+  .section--contrast,
+  .section--overlay {
+    padding: 4rem 1.5rem;
   }
-}
 
-ul {
-  margin: 0 0 1rem 1.2rem;
-  padding: 0;
-  line-height: 1.6;
-}
+  .overline::before {
+    display: none;
+  }
 
-li {
-  margin-bottom: 0.5rem;
+  .badge {
+    letter-spacing: 0.18em;
+  }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,387 @@
+:root {
+  --bg-primary: #0b0b0b;
+  --text-primary: #e9e6df;
+  --text-muted: rgba(233, 230, 223, 0.72);
+  --accent: #8b0f0f;
+  --accent-soft: rgba(139, 15, 15, 0.35);
+  --max-width: 1080px;
+  --font-heading: "Archivo Condensed", "Impact", "Haettenschweiler", "Arial Narrow", sans-serif;
+  --font-body: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", "Consolas", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: -200px;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.25'/%3E%3C/svg%3E");
+  mix-blend-mode: screen;
+  opacity: 0.16;
+  animation: grain 12s steps(10) infinite;
+  z-index: 0;
+}
+
+@keyframes grain {
+  0% { transform: translate3d(0, 0, 0); }
+  100% { transform: translate3d(-10px, 10px, 0); }
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(11, 11, 11, 0.92);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(233, 230, 223, 0.08);
+}
+
+.nav-container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 1.25rem;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+}
+
+nav a {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+
+nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: transparent;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--text-primary);
+}
+
+nav a:hover::after,
+nav a:focus::after,
+nav a[aria-current="page"]::after {
+  background: var(--accent);
+  transform: scaleX(1);
+}
+
+main {
+  flex: 1;
+}
+
+.section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.section.hero {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.overline {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+h1, h2, h3, h4 {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.5rem;
+  color: var(--text-primary);
+}
+
+h1 {
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  line-height: 1.05;
+}
+
+p {
+  line-height: 1.6;
+  max-width: 72ch;
+}
+
+p.caption {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+a {
+  color: var(--accent);
+}
+
+a.button,
+button.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.9rem 1.4rem;
+  border: 1px solid var(--accent);
+  color: var(--text-primary);
+  text-decoration: none;
+  text-transform: uppercase;
+  font-family: var(--font-heading);
+  letter-spacing: 0.2em;
+  background: rgba(139, 15, 15, 0.1);
+  transition: background 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+a.button:hover,
+button.button:hover {
+  background: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px rgba(139, 15, 15, 0.35);
+}
+
+.grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.two-column {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.cards {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  padding: 1.5rem;
+  background: rgba(233, 230, 223, 0.02);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(139, 15, 15, 0.2);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.card:hover::before {
+  opacity: 1;
+}
+
+.card h3 {
+  margin-top: 0.5rem;
+}
+
+.headshot {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  background: linear-gradient(135deg, rgba(233, 230, 223, 0.08), rgba(233, 230, 223, 0));
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.gallery-item {
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  padding: 1rem;
+  background: rgba(233, 230, 223, 0.02);
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.gallery-item span {
+  font-family: var(--font-mono);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 2rem;
+}
+
+.table th,
+.table td {
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  padding: 1rem;
+  text-align: left;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+input, textarea {
+  background: rgba(233, 230, 223, 0.05);
+  border: 1px solid rgba(233, 230, 223, 0.18);
+  padding: 0.9rem 1rem;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  border-radius: 2px;
+}
+
+input:focus,
+textarea:focus {
+  outline: 1px solid var(--accent);
+  outline-offset: 0;
+}
+
+footer {
+  border-top: 1px solid rgba(233, 230, 223, 0.08);
+  padding: 2rem 1.5rem;
+  text-align: center;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+footer .container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(233, 230, 223, 0.18);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.section + .section {
+  border-top: 1px solid rgba(233, 230, 223, 0.08);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+blockquote {
+  border-left: 2px solid var(--accent);
+  padding-left: 1rem;
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  .nav-container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  nav {
+    width: 100%;
+  }
+
+  nav a {
+    font-size: 0.65rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+ul {
+  margin: 0 0 1rem 1.2rem;
+  padding: 0;
+  line-height: 1.6;
+}
+
+li {
+  margin-bottom: 0.5rem;
+}

--- a/cast-crew.html
+++ b/cast-crew.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cast &amp; Crew — Golgotha</title>
+  <meta name="description" content="Meet the cast and crew assembling the feature film Golgotha.">
+  <meta property="og:title" content="Cast &amp; Crew — Golgotha">
+  <meta property="og:description" content="Placeholder bios for the cast and crew of Golgotha.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/cast-crew.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html" aria-current="page">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="overline">Cast</div>
+      <h1>Performers inhabiting the dream.</h1>
+      <div class="grid cards" style="margin-top:3rem;">
+        <div class="card">
+          <div class="headshot">Placeholder</div>
+          <h3>David Hill &mdash; Lead</h3>
+          <p>A brooding performer with a history in psychological thrillers, bringing restrained intensity to Detective Hill.</p>
+        </div>
+        <div class="card">
+          <div class="headshot">Placeholder</div>
+          <h3>Elena Ward &mdash; Antagonist</h3>
+          <p>An enigmatic presence with theatre roots, embodying the cult&rsquo;s visionary whose hymns blur faith and manipulation.</p>
+        </div>
+        <div class="card">
+          <div class="headshot">Placeholder</div>
+          <h3>Micah &mdash; Prophetic Child</h3>
+          <p>A newcomer whose quiet gaze anchors the film&rsquo;s supernatural tone and mirrors the audience&rsquo;s awe.</p>
+        </div>
+        <div class="card">
+          <div class="headshot">Placeholder</div>
+          <h3>Captain Reyes &mdash; Mentor</h3>
+          <p>A seasoned character actor grounding the procedural stakes with weary authority and unexpected compassion.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="overline">Crew</div>
+      <h2>The artisans crafting our noir liturgy.</h2>
+      <div class="grid cards" style="margin-top:3rem;">
+        <div class="card">
+          <div class="headshot">Placeholder</div>
+          <h3>Director of Photography</h3>
+          <p>Specializes in chiaroscuro compositions, blending practical haze with controlled highlights for painterly horror.</p>
+        </div>
+        <div class="card">
+          <div class="headshot">Placeholder</div>
+          <h3>Production Designer</h3>
+          <p>Designs decaying cathedrals, interrogation chapels, and rain-slick streets with meticulous attention to ritual detail.</p>
+        </div>
+        <div class="card">
+          <div class="headshot">Placeholder</div>
+          <h3>Composer</h3>
+          <p>Crafts a minimalist score of bowed metals, whispered choirs, and analog tape textures that pulse like a heartbeat.</p>
+        </div>
+        <div class="card">
+          <div class="headshot">Placeholder</div>
+          <h3>Editor</h3>
+          <p>Shapes the narrative with lyrical pacing, intercutting visions and reality to keep audiences suspended between worlds.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/cast-crew.html
+++ b/cast-crew.html
@@ -34,9 +34,24 @@
   </header>
 
   <main>
-    <section class="section">
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Cast &amp; Crew</div>
+        <h1>Performers inhabiting the dream.</h1>
+        <p>We assemble a company of actors and artisans who understand Golgotha&rsquo;s blend of noir minimalism and supernatural fervor.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">In Conversation with Talent</span>
+        <div class="status-panel">
+          <p class="caption">Focus</p>
+          <p>Faces etched with loss. Hands fluent in ritual. Collaborators who treat genre as elevated ceremony.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--contrast">
       <div class="overline">Cast</div>
-      <h1>Performers inhabiting the dream.</h1>
+      <h2>Faces of the ritual.</h2>
       <div class="grid cards" style="margin-top:3rem;">
         <div class="card">
           <div class="headshot">Placeholder</div>
@@ -61,7 +76,7 @@
       </div>
     </section>
 
-    <section class="section">
+    <section class="section section--overlay">
       <div class="overline">Crew</div>
       <h2>The artisans crafting our noir liturgy.</h2>
       <div class="grid cards" style="margin-top:3rem;">

--- a/contact.html
+++ b/contact.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contact — Golgotha</title>
-  <meta name="description" content="Contact the Golgotha film team for press, partnerships, and investment.">
+  <meta name="description" content="Contact the Golgotha team for partnerships, press, and support.">
   <meta property="og:title" content="Contact — Golgotha">
-  <meta property="og:description" content="Reach the Golgotha team for inquiries and collaborations.">
+  <meta property="og:description" content="Reach the Golgotha team for investor calls, press, and collaborations.">
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/contact.html">
@@ -34,36 +34,48 @@
   </header>
 
   <main>
-    <section class="section">
-      <div class="overline">Contact</div>
-      <h1>Step into the investigation.</h1>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Contact</div>
+        <h1>Enter the investigation.</h1>
+        <p>Reach the Golgotha team for investor conversations, press coordination, or to join the audience of early believers.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--glow">Response within 48 hours</span>
+        <div class="status-panel">
+          <p class="caption">Direct Email</p>
+          <a class="button" href="mailto:hello@golgothafilm.com">hello@golgothafilm.com</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--overlay">
       <div class="grid two-column" style="margin-top:2.5rem;">
         <div>
-          <form action="#" method="post">
+          <form>
             <div class="form-group">
               <label for="name">Name</label>
-              <input type="text" id="name" name="name" placeholder="Your name" required>
+              <input id="name" name="name" type="text" placeholder="Your Name">
             </div>
             <div class="form-group">
               <label for="email">Email</label>
-              <input type="email" id="email" name="email" placeholder="you@example.com" required>
+              <input id="email" name="email" type="email" placeholder="you@example.com">
             </div>
             <div class="form-group">
               <label for="message">Message</label>
-              <textarea id="message" name="message" rows="5" placeholder="Tell us how you&rsquo;d like to collaborate"></textarea>
+              <textarea id="message" name="message" placeholder="Tell us how you&rsquo;d like to collaborate."></textarea>
             </div>
             <button class="button" type="submit">Send Message</button>
           </form>
         </div>
         <div>
-          <div class="card">
-            <p class="caption">Direct Line</p>
-            <p><a href="mailto:hello@golgothafilm.com">hello@golgothafilm.com</a></p>
-            <p class="caption" style="margin-top:1.5rem;">Production Office</p>
-            <p>Golgotha Film<br>1313 Nocturne Avenue<br>Suite 7<br>Los Angeles, CA 90012</p>
-            <p class="caption" style="margin-top:1.5rem;">Follow the Case</p>
-            <p><a href="https://buttondown.email/" target="_blank" rel="noopener">Buttondown Dispatch</a></p>
+          <p class="caption">Studio Address</p>
+          <div class="address-block">
+            Golgotha Film<br>
+            1111 Noir Avenue<br>
+            Los Angeles, CA 90001
           </div>
+          <p style="margin-top:2rem;">We coordinate investor calls via Cal.com and release production notes through Buttondown. Subscribe on the homepage for updates.</p>
         </div>
       </div>
     </section>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact — Golgotha</title>
+  <meta name="description" content="Contact the Golgotha film team for press, partnerships, and investment.">
+  <meta property="og:title" content="Contact — Golgotha">
+  <meta property="og:description" content="Reach the Golgotha team for inquiries and collaborations.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/contact.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html" aria-current="page">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="overline">Contact</div>
+      <h1>Step into the investigation.</h1>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <form action="#" method="post">
+            <div class="form-group">
+              <label for="name">Name</label>
+              <input type="text" id="name" name="name" placeholder="Your name" required>
+            </div>
+            <div class="form-group">
+              <label for="email">Email</label>
+              <input type="email" id="email" name="email" placeholder="you@example.com" required>
+            </div>
+            <div class="form-group">
+              <label for="message">Message</label>
+              <textarea id="message" name="message" rows="5" placeholder="Tell us how you&rsquo;d like to collaborate"></textarea>
+            </div>
+            <button class="button" type="submit">Send Message</button>
+          </form>
+        </div>
+        <div>
+          <div class="card">
+            <p class="caption">Direct Line</p>
+            <p><a href="mailto:hello@golgothafilm.com">hello@golgothafilm.com</a></p>
+            <p class="caption" style="margin-top:1.5rem;">Production Office</p>
+            <p>Golgotha Film<br>1313 Nocturne Avenue<br>Suite 7<br>Los Angeles, CA 90012</p>
+            <p class="caption" style="margin-top:1.5rem;">Follow the Case</p>
+            <p><a href="https://buttondown.email/" target="_blank" rel="noopener">Buttondown Dispatch</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/director.html
+++ b/director.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Director — Golgotha</title>
+  <meta name="description" content="Director's statement for Golgotha, a poetic horror-noir feature film.">
+  <meta property="og:title" content="Director — Golgotha">
+  <meta property="og:description" content="The director of Golgotha treats horror as poetry, orchestrating grief, faith, and memory.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/director.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html" aria-current="page">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="overline">Director&rsquo;s Statement</div>
+      <h1>Horror as poetry, memory as scripture.</h1>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <p>I direct Golgotha as a visual symphony, treating dread like a composition of silence, ritual, and sudden light. Each frame leans into the tension between brutal reality and metaphysical suggestion.</p>
+          <p>Our palette recalls decayed cathedrals and nocturnal alleyways, bending the city into a living reliquary. Grief, faith, and memory become characters that haunt Detective Hill until he surrenders to transformation.</p>
+        </div>
+        <div>
+          <p>The influences are clear: Lynch&rsquo;s dream-logic, Eggers&rsquo;s devotion to folklore and ritual, Aster&rsquo;s psychological excavation. Yet Golgotha speaks with its own restrained, indelible voice&mdash;a poem etched in smoke and sirens.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/director.html
+++ b/director.html
@@ -56,11 +56,12 @@
     <section class="section section--tight">
       <div class="grid two-column" style="margin-top:2.5rem;">
         <div>
-          <p>Our palette recalls decayed cathedrals and nocturnal alleyways, bending the city into a living reliquary. Grief, faith, and memory become characters that haunt Detective Hill until he surrenders to transformation.</p>
-          <p>Every location is treated like a sacred site defaced by modern neglect. We shoot through layers of smoke, rain, and glass to trap our detective between worlds—presenting horror as a prayer answered in whispers.</p>
+          <p>Cinema is made of the fabric of the universe &mdash; light, sound, and time. Therefore, it is the perfect art form to tell a story with such existential weight. My approach to filmmaking is a little different than some. My background is in the avant-garde, and so I like to think of a film as something between a moving painting and a symphony.</p>
+          <p>Every single shot must be handled with the same attention to detail that an artist would bring to a canvas. Every frame must be a painting. Anything in the frame, from the colors to the lighting, blocking, and movement, can shift the mood of an image ever so slightly.</p>
         </div>
         <div>
-          <p>The film&rsquo;s tone is restrained yet indelible. Stillness holds as much power as violence. We move the camera like a slow procession, letting the audience feel the echo of loss before the next revelation erupts.</p>
+          <p>Think about how different musical notes fit together to make a chord with its own distinct emotional value. That&rsquo;s a shot &mdash; a series of small visual decisions that converge to express a distinct emotion. In music, chords are arranged amidst other chords to create a piece of music. That is editing: comparing images together to create a fluid and dynamic emotional flow. That is cinema.</p>
+          <p>A visual symphony.</p>
         </div>
       </div>
     </section>

--- a/director.html
+++ b/director.html
@@ -34,16 +34,33 @@
   </header>
 
   <main>
-    <section class="section">
-      <div class="overline">Director&rsquo;s Statement</div>
-      <h1>Horror as poetry, memory as scripture.</h1>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Director&rsquo;s Statement</div>
+        <h1>Horror as poetry, memory as scripture.</h1>
+        <p>I direct Golgotha as a visual symphony, treating dread like a composition of silence, ritual, and sudden light. Each frame leans into the tension between brutal reality and metaphysical suggestion.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--glow">Writer / Director</span>
+        <div class="status-panel">
+          <p class="caption">Influences</p>
+          <ul class="list-soft">
+            <li>David Lynch&rsquo;s dream-logic</li>
+            <li>Robert Eggers&rsquo;s devotion to ritual</li>
+            <li>Ari Aster&rsquo;s psychological excavation</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
       <div class="grid two-column" style="margin-top:2.5rem;">
         <div>
-          <p>I direct Golgotha as a visual symphony, treating dread like a composition of silence, ritual, and sudden light. Each frame leans into the tension between brutal reality and metaphysical suggestion.</p>
           <p>Our palette recalls decayed cathedrals and nocturnal alleyways, bending the city into a living reliquary. Grief, faith, and memory become characters that haunt Detective Hill until he surrenders to transformation.</p>
+          <p>Every location is treated like a sacred site defaced by modern neglect. We shoot through layers of smoke, rain, and glass to trap our detective between worlds—presenting horror as a prayer answered in whispers.</p>
         </div>
         <div>
-          <p>The influences are clear: Lynch&rsquo;s dream-logic, Eggers&rsquo;s devotion to folklore and ritual, Aster&rsquo;s psychological excavation. Yet Golgotha speaks with its own restrained, indelible voice&mdash;a poem etched in smoke and sirens.</p>
+          <p>The film&rsquo;s tone is restrained yet indelible. Stillness holds as much power as violence. We move the camera like a slow procession, letting the audience feel the echo of loss before the next revelation erupts.</p>
         </div>
       </div>
     </section>

--- a/gallery.html
+++ b/gallery.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Gallery — Golgotha</title>
-  <meta name="description" content="Conceptual stills and mood imagery for Golgotha.">
+  <meta name="description" content="Placeholder stills for the feature film Golgotha.">
   <meta property="og:title" content="Gallery — Golgotha">
-  <meta property="og:description" content="Explore labeled still placeholders for Golgotha.">
+  <meta property="og:description" content="Explore twelve placeholder stills capturing Golgotha&rsquo;s mood.">
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/gallery.html">
@@ -34,22 +34,39 @@
   </header>
 
   <main>
-    <section class="section">
-      <div class="overline">Gallery</div>
-      <h1>Still placeholders &mdash; the city before the fall.</h1>
-      <div class="gallery-grid" style="margin-top:3rem;">
-        <div class="gallery-item"><span>Still 01 &mdash; Rain-slick Street</span></div>
-        <div class="gallery-item"><span>Still 02 &mdash; Candlelit Chapel</span></div>
-        <div class="gallery-item"><span>Still 03 &mdash; Evidence Wall</span></div>
-        <div class="gallery-item"><span>Still 04 &mdash; Station of Grief</span></div>
-        <div class="gallery-item"><span>Still 05 &mdash; Detective&rsquo;s Apartment</span></div>
-        <div class="gallery-item"><span>Still 06 &mdash; Ritual Mask</span></div>
-        <div class="gallery-item"><span>Still 07 &mdash; Cathedral Steps</span></div>
-        <div class="gallery-item"><span>Still 08 &mdash; Vision in Fog</span></div>
-        <div class="gallery-item"><span>Still 09 &mdash; Autopsy Theater</span></div>
-        <div class="gallery-item"><span>Still 10 &mdash; Prophetic Sketches</span></div>
-        <div class="gallery-item"><span>Still 11 &mdash; Blackout Alley</span></div>
-        <div class="gallery-item"><span>Still 12 &mdash; Final Descent</span></div>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Gallery</div>
+        <h1>Atmospheric stills &mdash; arriving soon.</h1>
+        <p>Twelve frames capturing Golgotha&rsquo;s palette of bloodlight, fog, and cathedral shadows. Each still is a placeholder, a promise of the visual fever dream in production.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">Lookbook In Development</span>
+        <div class="status-panel">
+          <p class="caption">Visual Motifs</p>
+          <ul class="list-soft">
+            <li>35mm grain &amp; analog flares</li>
+            <li>Candlelit sanctuaries</li>
+            <li>Rain-soaked neon corridors</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="gallery-grid">
+        <div class="gallery-item"><span>Still 01 &mdash; Alley of Echoes</span></div>
+        <div class="gallery-item"><span>Still 02 &mdash; Chapel Vigil</span></div>
+        <div class="gallery-item"><span>Still 03 &mdash; Evidence Shrine</span></div>
+        <div class="gallery-item"><span>Still 04 &mdash; The Red Phone</span></div>
+        <div class="gallery-item"><span>Still 05 &mdash; Rainlit Confession</span></div>
+        <div class="gallery-item"><span>Still 06 &mdash; Cathedral Steps</span></div>
+        <div class="gallery-item"><span>Still 07 &mdash; Midnight Procession</span></div>
+        <div class="gallery-item"><span>Still 08 &mdash; Station Ghosts</span></div>
+        <div class="gallery-item"><span>Still 09 &mdash; Flicker Room</span></div>
+        <div class="gallery-item"><span>Still 10 &mdash; Tunnel Hymn</span></div>
+        <div class="gallery-item"><span>Still 11 &mdash; Relic Archive</span></div>
+        <div class="gallery-item"><span>Still 12 &mdash; Dawn Anointing</span></div>
       </div>
     </section>
   </main>

--- a/gallery.html
+++ b/gallery.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gallery — Golgotha</title>
+  <meta name="description" content="Conceptual stills and mood imagery for Golgotha.">
+  <meta property="og:title" content="Gallery — Golgotha">
+  <meta property="og:description" content="Explore labeled still placeholders for Golgotha.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/gallery.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html" aria-current="page">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="overline">Gallery</div>
+      <h1>Still placeholders &mdash; the city before the fall.</h1>
+      <div class="gallery-grid" style="margin-top:3rem;">
+        <div class="gallery-item"><span>Still 01 &mdash; Rain-slick Street</span></div>
+        <div class="gallery-item"><span>Still 02 &mdash; Candlelit Chapel</span></div>
+        <div class="gallery-item"><span>Still 03 &mdash; Evidence Wall</span></div>
+        <div class="gallery-item"><span>Still 04 &mdash; Station of Grief</span></div>
+        <div class="gallery-item"><span>Still 05 &mdash; Detective&rsquo;s Apartment</span></div>
+        <div class="gallery-item"><span>Still 06 &mdash; Ritual Mask</span></div>
+        <div class="gallery-item"><span>Still 07 &mdash; Cathedral Steps</span></div>
+        <div class="gallery-item"><span>Still 08 &mdash; Vision in Fog</span></div>
+        <div class="gallery-item"><span>Still 09 &mdash; Autopsy Theater</span></div>
+        <div class="gallery-item"><span>Still 10 &mdash; Prophetic Sketches</span></div>
+        <div class="gallery-item"><span>Still 11 &mdash; Blackout Alley</span></div>
+        <div class="gallery-item"><span>Still 12 &mdash; Final Descent</span></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -35,20 +35,40 @@
 
   <main>
     <section class="section hero">
-      <div class="overline">Feature Film / Horror Noir</div>
-      <h1>Detective David Hill descends into a city of grief, faith, and impossible crimes.</h1>
-      <p>Golgotha is a poetic horror-noir feature that blends the haunted surrealism of David Lynch with the stark ritualism of Robert Eggers and the emotional dread of Ari Aster. Our jaded detective navigates a cathedral of shadows where every clue resurrects memory, every suspect echoes the dead, and redemption is as perilous as damnation.</p>
-      <div class="hero-actions">
-        <a class="button" href="investors.html#deck">View Investor Overview</a>
-        <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule a Call</a>
-        <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Support via Stripe</a>
+      <div class="hero-content">
+        <div class="overline">Feature Film / Horror Noir</div>
+        <h1>The city keeps the dead awake.</h1>
+        <p class="hero-lede">Detective David Hill stalks impossible crimes across a metropolis of candlelit tunnels, sodium rain, and whispered confessionals. Golgotha blends Lynchian dream-logic with nocturnal noir, inviting investors and believers into a ritual of grief, faith, and resurrection.</p>
+        <div class="hero-actions">
+          <a class="button" href="investors.html#deck">View Investor Overview</a>
+          <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule a Call</a>
+          <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Support via Stripe</a>
+        </div>
+        <div class="hero-meta">
+          <span class="badge badge--glow">Now Packaging — Financing &amp; Audience Building</span>
+          <span>Phase: In Casting &amp; Pre-Production</span>
+          <span>Raise Target: $100K Development / Packaging</span>
+        </div>
       </div>
-      <div class="badge">Now Packaging &mdash; Financing &amp; Audience Building</div>
+      <div class="hero-media">
+        <div class="hero-frame">
+          <div class="hero-poster">
+            <span>Poster reveal coming soon</span>
+          </div>
+        </div>
+        <div class="status-panel">
+          <p class="caption">Investment Hooks</p>
+          <strong>Elevated horror noir</strong>
+          <p>Psychological dread, cathedral-scale visuals, and a director treating horror as whispered poetry.</p>
+        </div>
+      </div>
     </section>
 
-    <section class="section">
-      <h2>Key Momentum</h2>
-      <div class="grid two-column">
+    <section class="section section--contrast">
+      <div class="overline">Momentum</div>
+      <h2>Signals investors are watching.</h2>
+      <p class="hero-lede">Our packaging sprint positions Golgotha to capture financing while cultivating an obsessive audience.</p>
+      <div class="grid two-column" style="margin-top:2.5rem;">
         <div>
           <p class="caption">Primary Goal</p>
           <p>Secure financing partners and early believers who resonate with Golgotha&rsquo;s austere, lyrical vision.</p>
@@ -58,21 +78,21 @@
           <p>Activate an audience who follows Detective Hill&rsquo;s descent through our newsletters, screenings, and supporter community.</p>
         </div>
       </div>
-      <div class="grid cards" style="margin-top:2rem;">
+      <div class="grid cards" style="margin-top:2.5rem;">
         <div class="card">
-          <p class="caption">KPI: EMAIL SIGNUPS</p>
+          <p class="caption">KPI: Email Signups</p>
           <h3>Gather the faithful</h3>
           <p>Subscribe to the Buttondown dispatch to receive updates from the Golgotha investigation room.</p>
           <a class="button" href="https://buttondown.email/" target="_blank" rel="noopener">Join Buttondown</a>
         </div>
         <div class="card">
-          <p class="caption">KPI: INVESTOR MEETINGS</p>
+          <p class="caption">KPI: Investor Meetings</p>
           <h3>Enter the briefing</h3>
           <p>Schedule a private session via Cal.com to review our materials, production plan, and financial strategy.</p>
           <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Book via Cal.com</a>
         </div>
         <div class="card">
-          <p class="caption">KPI: DONATIONS</p>
+          <p class="caption">KPI: Donations</p>
           <h3>Underwrite the hunt</h3>
           <p>Support the development phase with a Stripe Checkout contribution. Donations are not equity investments.</p>
           <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Stripe Checkout</a>
@@ -80,15 +100,16 @@
       </div>
     </section>
 
-    <section class="section">
-      <h2>Atmosphere</h2>
-      <div class="grid two-column">
+    <section class="section section--overlay">
+      <div class="overline">Atmosphere</div>
+      <h2>A devotion to cinematic dread.</h2>
+      <div class="grid two-column" style="margin-top:2.5rem;">
         <div>
           <p>Industrial fog, sodium-lit rain, and candlelit chapels. Golgotha merges the intimacy of a psychological confessional with the suspense of a nightmare procedural. The film translates grief into images: flickering projector light, slow-motion ash, whispered hymns inside abandoned stations.</p>
         </div>
         <div>
           <blockquote>
-            Horror is the liturgy, noir is the confession booth. Detective Hill is both penitent and sinner, translating unspeakable loss into ritual justice.
+            Horror is the liturgy, noir is the confessional booth. Detective Hill is both penitent and sinner, translating unspeakable loss into ritual justice.
           </blockquote>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Golgotha — A Poetic Horror-Noir Feature Film</title>
+  <meta name="description" content="Golgotha is a poetic horror-noir following Detective David Hill through grief, faith, and the supernatural.">
+  <meta property="og:title" content="Golgotha — Poetic Horror-Noir Feature Film">
+  <meta property="og:description" content="Detective David Hill confronts grief and the supernatural in an arthouse horror-noir.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html" aria-current="page">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section hero">
+      <div class="overline">Feature Film / Horror Noir</div>
+      <h1>Detective David Hill descends into a city of grief, faith, and impossible crimes.</h1>
+      <p>Golgotha is a poetic horror-noir feature that blends the haunted surrealism of David Lynch with the stark ritualism of Robert Eggers and the emotional dread of Ari Aster. Our jaded detective navigates a cathedral of shadows where every clue resurrects memory, every suspect echoes the dead, and redemption is as perilous as damnation.</p>
+      <div class="hero-actions">
+        <a class="button" href="investors.html#deck">View Investor Overview</a>
+        <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule a Call</a>
+        <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Support via Stripe</a>
+      </div>
+      <div class="badge">Now Packaging &mdash; Financing &amp; Audience Building</div>
+    </section>
+
+    <section class="section">
+      <h2>Key Momentum</h2>
+      <div class="grid two-column">
+        <div>
+          <p class="caption">Primary Goal</p>
+          <p>Secure financing partners and early believers who resonate with Golgotha&rsquo;s austere, lyrical vision.</p>
+        </div>
+        <div>
+          <p class="caption">Secondary Goal</p>
+          <p>Activate an audience who follows Detective Hill&rsquo;s descent through our newsletters, screenings, and supporter community.</p>
+        </div>
+      </div>
+      <div class="grid cards" style="margin-top:2rem;">
+        <div class="card">
+          <p class="caption">KPI: EMAIL SIGNUPS</p>
+          <h3>Gather the faithful</h3>
+          <p>Subscribe to the Buttondown dispatch to receive updates from the Golgotha investigation room.</p>
+          <a class="button" href="https://buttondown.email/" target="_blank" rel="noopener">Join Buttondown</a>
+        </div>
+        <div class="card">
+          <p class="caption">KPI: INVESTOR MEETINGS</p>
+          <h3>Enter the briefing</h3>
+          <p>Schedule a private session via Cal.com to review our materials, production plan, and financial strategy.</p>
+          <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Book via Cal.com</a>
+        </div>
+        <div class="card">
+          <p class="caption">KPI: DONATIONS</p>
+          <h3>Underwrite the hunt</h3>
+          <p>Support the development phase with a Stripe Checkout contribution. Donations are not equity investments.</p>
+          <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Stripe Checkout</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Atmosphere</h2>
+      <div class="grid two-column">
+        <div>
+          <p>Industrial fog, sodium-lit rain, and candlelit chapels. Golgotha merges the intimacy of a psychological confessional with the suspense of a nightmare procedural. The film translates grief into images: flickering projector light, slow-motion ash, whispered hymns inside abandoned stations.</p>
+        </div>
+        <div>
+          <blockquote>
+            Horror is the liturgy, noir is the confession booth. Detective Hill is both penitent and sinner, translating unspeakable loss into ritual justice.
+          </blockquote>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Golgotha — A Poetic Horror-Noir Feature Film</title>
-  <meta name="description" content="Golgotha is a poetic horror-noir following Detective David Hill through grief, faith, and the supernatural.">
+  <meta name="description" content="DAVID HILL, a jaded detective, wrestles with existential angst while investigating surreal and supernatural crimes.">
   <meta property="og:title" content="Golgotha — Poetic Horror-Noir Feature Film">
-  <meta property="og:description" content="Detective David Hill confronts grief and the supernatural in an arthouse horror-noir.">
+  <meta property="og:description" content="DAVID HILL, a jaded detective, wrestles with existential angst while investigating surreal and supernatural crimes.">
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/">
@@ -37,8 +37,8 @@
     <section class="section hero">
       <div class="hero-content">
         <div class="overline">Feature Film / Horror Noir</div>
-        <h1>The city keeps the dead awake.</h1>
-        <p class="hero-lede">Detective David Hill stalks impossible crimes across a metropolis of candlelit tunnels, sodium rain, and whispered confessionals. Golgotha blends Lynchian dream-logic with nocturnal noir, inviting investors and believers into a ritual of grief, faith, and resurrection.</p>
+        <h1>DAVID HILL, a jaded detective, wrestles with existential angst as he investigates a series of increasingly surreal and supernatural crimes.</h1>
+        <p class="hero-lede">Golgotha draws on the cinematic lineage of David Lynch, Robert Eggers, and Ari Aster to fuse arthouse restraint with midnight dread. Investors and audiences are invited into a poetic investigation where grief, faith, and memory echo through sodium-lit rain and candlelit sanctuaries.</p>
         <div class="hero-actions">
           <a class="button" href="investors.html#deck">View Investor Overview</a>
           <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule a Call</a>
@@ -111,6 +111,27 @@
           <blockquote>
             Horror is the liturgy, noir is the confessional booth. Detective Hill is both penitent and sinner, translating unspeakable loss into ritual justice.
           </blockquote>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="overline">Audience</div>
+      <h2>Who we&rsquo;re calling into the dark.</h2>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <ul class="list-soft">
+            <li>Tarkovsky devotees with an appetite for horror</li>
+            <li>Fans of David Lynch&rsquo;s dream-logic investigations</li>
+            <li>Giallo aficionados craving artful dread</li>
+          </ul>
+        </div>
+        <div>
+          <ul class="list-soft">
+            <li>College-educated Millennials and Gen Z drawn to the arts</li>
+            <li>Collectors of boutique physical media releases</li>
+            <li>Visual artists, poets, photographers, and painters</li>
+          </ul>
         </div>
       </div>
     </section>

--- a/investors.html
+++ b/investors.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Investors — Golgotha</title>
+  <meta name="description" content="Investor overview for the feature film Golgotha.">
+  <meta property="og:title" content="Investors — Golgotha">
+  <meta property="og:description" content="Review the investor overview, deck request, and support options for Golgotha.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/investors.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html" aria-current="page">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section" id="deck">
+      <div class="overline">Investors</div>
+      <h1>A precise plan for a $100K raise.</h1>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <p>Golgotha is entering casting and pre-production with a financing target of <strong>$100,000</strong> for development and packaging. We are gathering equity partners, executive producers, and aligned patrons who believe in elevated genre storytelling with international appeal.</p>
+          <p class="caption">Status &mdash; In casting &amp; pre-production.</p>
+        </div>
+        <div>
+          <div class="card">
+            <p class="caption">Highlights</p>
+            <ul>
+              <li>Budget tiers designed for scalable expansion to full production.</li>
+              <li>Sales strategy balancing prestige festivals with targeted genre markets.</li>
+              <li>Seasoned department heads with horror, noir, and arthouse credits.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="hero-actions" style="margin-top:2rem;">
+        <a class="button" href="mailto:hello@golgothafilm.com?subject=Golgotha%20Deck%20Request">Request the Deck</a>
+        <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule an Investor Call</a>
+        <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Support via Stripe</a>
+      </div>
+      <p class="caption" style="margin-top:1rem;">Donations via Stripe are tax-deductible only if processed through a fiscal sponsor and do not constitute an investment or offer of securities.</p>
+    </section>
+
+    <section class="section">
+      <h2>Key Performance Indicators</h2>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th>Focus</th>
+            <th>Tools</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Email Signups</td>
+            <td>Grow Buttondown list with director&rsquo;s journals, mood reels, and production updates.</td>
+            <td><a href="https://buttondown.email/" target="_blank" rel="noopener">Buttondown</a></td>
+          </tr>
+          <tr>
+            <td>Donations</td>
+            <td>Invite contributions to bridge development expenses, location scouts, and lookbook shoots.</td>
+            <td><a href="https://buy.stripe.com/" target="_blank" rel="noopener">Stripe Checkout</a></td>
+          </tr>
+          <tr>
+            <td>Investor Meetings</td>
+            <td>Secure strategic conversations with financiers and producers through structured calendaring.</td>
+            <td><a href="https://cal.com/" target="_blank" rel="noopener">Cal.com</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="section">
+      <h2>Disclaimer</h2>
+      <p>Information on this page is for discussion purposes only and does not constitute a solicitation or offer to sell securities. Any investment opportunities will be presented separately and in accordance with applicable securities laws. Support through Stripe Checkout is a non-refundable donation that does not provide ownership or profit participation.</p>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/investors.html
+++ b/investors.html
@@ -34,35 +34,35 @@
   </header>
 
   <main>
-    <section class="section" id="deck">
-      <div class="overline">Investors</div>
-      <h1>A precise plan for a $100K raise.</h1>
-      <div class="grid two-column" style="margin-top:2.5rem;">
-        <div>
-          <p>Golgotha is entering casting and pre-production with a financing target of <strong>$100,000</strong> for development and packaging. We are gathering equity partners, executive producers, and aligned patrons who believe in elevated genre storytelling with international appeal.</p>
-          <p class="caption">Status &mdash; In casting &amp; pre-production.</p>
+    <section class="section page-hero" id="deck">
+      <div class="page-hero__content">
+        <div class="overline">Investors</div>
+        <h1>A precision plan for a $100K raise.</h1>
+        <p>Golgotha is entering casting and pre-production with a development target of <strong>$100,000</strong>. We invite equity partners, executive producers, and patrons aligned with elevated genre filmmaking to help package the film.</p>
+        <div class="hero-actions">
+          <a class="button" href="mailto:hello@golgothafilm.com?subject=Golgotha%20Deck%20Request">Request the Deck</a>
+          <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule an Investor Call</a>
+          <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Support via Stripe</a>
         </div>
-        <div>
-          <div class="card">
-            <p class="caption">Highlights</p>
-            <ul>
-              <li>Budget tiers designed for scalable expansion to full production.</li>
-              <li>Sales strategy balancing prestige festivals with targeted genre markets.</li>
-              <li>Seasoned department heads with horror, noir, and arthouse credits.</li>
-            </ul>
-          </div>
+        <p class="caption">Donations via Stripe are not investments and may be tax-deductible only if routed through a fiscal sponsor.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--glow">Status &mdash; In Casting &amp; Pre-Production</span>
+        <div class="status-panel">
+          <p class="caption">Snapshot</p>
+          <ul class="list-soft">
+            <li>Budget tiers designed for scalable expansion</li>
+            <li>Prestige genre festival and sales roadmap</li>
+            <li>Seasoned department heads from horror &amp; noir</li>
+          </ul>
         </div>
       </div>
-      <div class="hero-actions" style="margin-top:2rem;">
-        <a class="button" href="mailto:hello@golgothafilm.com?subject=Golgotha%20Deck%20Request">Request the Deck</a>
-        <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule an Investor Call</a>
-        <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Support via Stripe</a>
-      </div>
-      <p class="caption" style="margin-top:1rem;">Donations via Stripe are tax-deductible only if processed through a fiscal sponsor and do not constitute an investment or offer of securities.</p>
     </section>
 
-    <section class="section">
-      <h2>Key Performance Indicators</h2>
+    <section class="section section--contrast">
+      <div class="overline">Key Performance Indicators</div>
+      <h2>Leading metrics guiding the raise.</h2>
+      <p class="hero-lede">Audience traction and investor interest are measured through three priority channels.</p>
       <table class="table">
         <thead>
           <tr>
@@ -91,8 +91,8 @@
       </table>
     </section>
 
-    <section class="section">
-      <h2>Disclaimer</h2>
+    <section class="section section--tight">
+      <div class="overline">Disclaimer</div>
       <p>Information on this page is for discussion purposes only and does not constitute a solicitation or offer to sell securities. Any investment opportunities will be presented separately and in accordance with applicable securities laws. Support through Stripe Checkout is a non-refundable donation that does not provide ownership or profit participation.</p>
     </section>
   </main>

--- a/investors.html
+++ b/investors.html
@@ -91,6 +91,27 @@
       </table>
     </section>
 
+    <section class="section section--overlay">
+      <div class="overline">Audience Alignment</div>
+      <h2>Communities primed for Golgotha.</h2>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <ul class="list-soft">
+            <li>Tarkovsky fans who love horror</li>
+            <li>Followers of David Lynch&rsquo;s dreamlike investigations</li>
+            <li>Giallo enthusiasts seeking elevated dread</li>
+          </ul>
+        </div>
+        <div>
+          <ul class="list-soft">
+            <li>College-educated Millennials and Gen Z with an arts focus</li>
+            <li>Collectors of boutique physical media and limited editions</li>
+            <li>Visual artists, poets, photographers, and painters</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
     <section class="section section--tight">
       <div class="overline">Disclaimer</div>
       <p>Information on this page is for discussion purposes only and does not constitute a solicitation or offer to sell securities. Any investment opportunities will be presented separately and in accordance with applicable securities laws. Support through Stripe Checkout is a non-refundable donation that does not provide ownership or profit participation.</p>

--- a/press.html
+++ b/press.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Press — Golgotha</title>
+  <meta name="description" content="Press and festival updates for Golgotha.">
+  <meta property="og:title" content="Press — Golgotha">
+  <meta property="og:description" content="Press resources and updates for Golgotha.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/press.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html" aria-current="page">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="overline">Press &amp; Festivals</div>
+      <h1>Building credibility with precision.</h1>
+      <p class="caption">Status</p>
+      <p>No press yet. We are actively cultivating partnerships with genre outlets, festival programmers, and critics aligned with poetic horror and noir.</p>
+      <div class="card" style="margin-top:2rem;">
+        <p class="caption">Coming Soon</p>
+        <p>Press kit, festival submissions timeline, and exclusive stills will be available upon announcement.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/press.html
+++ b/press.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Press — Golgotha</title>
-  <meta name="description" content="Press and festival updates for Golgotha.">
+  <meta name="description" content="Press and festival updates for the feature film Golgotha.">
   <meta property="og:title" content="Press — Golgotha">
-  <meta property="og:description" content="Press resources and updates for Golgotha.">
+  <meta property="og:description" content="Placeholder press information for Golgotha.">
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/press.html">
@@ -34,14 +34,22 @@
   </header>
 
   <main>
-    <section class="section">
-      <div class="overline">Press &amp; Festivals</div>
-      <h1>Building credibility with precision.</h1>
-      <p class="caption">Status</p>
-      <p>No press yet. We are actively cultivating partnerships with genre outlets, festival programmers, and critics aligned with poetic horror and noir.</p>
-      <div class="card" style="margin-top:2rem;">
-        <p class="caption">Coming Soon</p>
-        <p>Press kit, festival submissions timeline, and exclusive stills will be available upon announcement.</p>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Press &amp; Festivals</div>
+        <h1>Building credibility before the spotlight.</h1>
+        <p>As Golgotha packages for financing, we&rsquo;re curating materials, critics, and festival strategies that align with elevated genre storytelling.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">Press Kit In Development</span>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="status-panel">
+        <p class="caption">Current Status</p>
+        <strong>No press yet</strong>
+        <p>Press releases, festival submissions, and critic outreach are planned for post-packaging milestones. Media inquiries can be initiated through the contact page.</p>
       </div>
     </section>
   </main>

--- a/public/poster-og-placeholder.svg
+++ b/public/poster-og-placeholder.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Golgotha Poster Placeholder</title>
+  <desc id="desc">Text-based placeholder for the Golgotha poster artwork.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0B0B0B" />
+      <stop offset="100%" stop-color="#1F0B0B" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <g fill="none" stroke="rgba(233,230,223,0.15)" stroke-width="1">
+    <path d="M0 70 H1200" />
+    <path d="M0 560 H1200" />
+    <path d="M120 0 V630" />
+    <path d="M1080 0 V630" />
+  </g>
+  <text x="50%" y="45%" fill="#E9E6DF" font-family="'Archivo Condensed', 'Arial Narrow', sans-serif" font-size="96" text-anchor="middle" letter-spacing="12" text-transform="uppercase">GOLGOTHA</text>
+  <text x="50%" y="60%" fill="#8B0F0F" font-family="'IBM Plex Mono', monospace" font-size="28" text-anchor="middle" letter-spacing="18" text-transform="uppercase">Poetic Horror - Noir Feature</text>
+</svg>

--- a/screenings.html
+++ b/screenings.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Screenings — Golgotha</title>
+  <meta name="description" content="Screening schedule for Golgotha.">
+  <meta property="og:title" content="Screenings — Golgotha">
+  <meta property="og:description" content="Stay updated on Golgotha screenings and events.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/screenings.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html" aria-current="page">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="overline">Screenings</div>
+      <h1>Witness the investigation on the big screen.</h1>
+      <p>No screenings yet. As we progress through casting and pre-production, we will announce private previews, festival premieres, and special investor showcases.</p>
+      <div class="card" style="margin-top:2rem;">
+        <p class="caption">Stay Informed</p>
+        <p>Join the Buttondown list to receive the first invitations to teasers, table reads, and preview events.</p>
+        <a class="button" href="https://buttondown.email/" target="_blank" rel="noopener">Join Buttondown</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/screenings.html
+++ b/screenings.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Screenings — Golgotha</title>
-  <meta name="description" content="Screening schedule for Golgotha.">
+  <meta name="description" content="Screening announcements for the feature film Golgotha.">
   <meta property="og:title" content="Screenings — Golgotha">
-  <meta property="og:description" content="Stay updated on Golgotha screenings and events.">
+  <meta property="og:description" content="Placeholder screening information for Golgotha.">
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/screenings.html">
@@ -34,14 +34,22 @@
   </header>
 
   <main>
-    <section class="section">
-      <div class="overline">Screenings</div>
-      <h1>Witness the investigation on the big screen.</h1>
-      <p>No screenings yet. As we progress through casting and pre-production, we will announce private previews, festival premieres, and special investor showcases.</p>
-      <div class="card" style="margin-top:2rem;">
-        <p class="caption">Stay Informed</p>
-        <p>Join the Buttondown list to receive the first invitations to teasers, table reads, and preview events.</p>
-        <a class="button" href="https://buttondown.email/" target="_blank" rel="noopener">Join Buttondown</a>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Screenings</div>
+        <h1>Await the first communion.</h1>
+        <p>The premiere strategy targets genre festivals with prestige leanings, followed by bespoke event screenings that double as immersive rituals.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">Festival Run Pending</span>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="status-panel">
+        <p class="caption">Current Status</p>
+        <strong>No screenings yet</strong>
+        <p>Dates will be announced once financing closes and production locks. Investors and press will receive first access via Buttondown.</p>
       </div>
     </section>
   </main>

--- a/story.html
+++ b/story.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Story — Golgotha</title>
+  <meta name="description" content="Read the three-act synopsis of Golgotha, a poetic horror-noir feature film.">
+  <meta property="og:title" content="Story — Golgotha">
+  <meta property="og:description" content="Detective David Hill navigates grief, faith, and supernatural crimes in Golgotha.">
+  <meta property="og:image" content="/public/poster-og-placeholder.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/story.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html" aria-current="page">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="overline">Story</div>
+      <h1>Three Acts inside a haunted metropolis.</h1>
+      <div class="grid cards" style="margin-top:3rem;">
+        <div class="card">
+          <p class="caption">Act I — The Wake</p>
+          <p>Detective David Hill is assigned to a ritualistic murder that mirrors the unsolved death of his wife. Visions surge through sodium-lit rain and stained glass as Hill meets a prophetic child who sketches crime scenes before they occur.</p>
+        </div>
+        <div class="card">
+          <p class="caption">Act II — Stations</p>
+          <p>Hill tracks a cult of mourners who stage miracles for a hidden audience of the bereaved. Each interrogation unfolds like a confessional, exposing Hill&rsquo;s buried guilt and opening seams between memory and the waking world.</p>
+        </div>
+        <div class="card">
+          <p class="caption">Act III — Golgotha</p>
+          <p>With the city plunged into blackout, Hill descends into catacombs beneath a derelict cathedral. The final revelation forces him to confront a choice: resurrect the past at a terrible price, or accept loss and end the cycle of ritual bloodshed.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/story.html
+++ b/story.html
@@ -37,8 +37,8 @@
     <section class="section page-hero">
       <div class="page-hero__content">
         <div class="overline">Story</div>
-        <h1>Three acts inside a haunted metropolis.</h1>
-        <p>Detective David Hill&rsquo;s investigation bends grief into ritual. Each act escalates the collision between faith, memory, and the city&rsquo;s secret congregation of mourners.</p>
+        <h1>An episodic descent into grief and apparition.</h1>
+        <p>The film unfolds in three investigations. Each chapter follows DAVID HILL as he confronts a murder, its spectral residue, and the way memory claws at the living. The film employs a threefold episodic structure&mdash;each section shows a murder and its investigation by our stoic protagonist.</p>
       </div>
       <div class="page-hero__meta">
         <span class="badge badge--outline">Feature Narrative</span>
@@ -52,16 +52,16 @@
     <section class="section section--tight">
       <div class="grid cards" style="margin-top:3rem;">
         <div class="card">
-          <p class="caption">Act I &mdash; The Wake</p>
-          <p>Detective David Hill is assigned to a ritualistic murder that mirrors the unsolved death of his wife. Visions surge through sodium-lit rain and stained glass as Hill meets a prophetic child who sketches crime scenes before they occur.</p>
+          <p class="caption">I. The Tragedy of Belle &amp; Enzo</p>
+          <p>In a seedy motel on the outskirts of town, BELLE is murdered by her boyfriend, ENZO, for money. In her dying vision she sees a tender family reunion, dead relatives welcoming her home. DAVID solves the crime with ease and grows frustrated by its bleak normalcy. After a brief pursuit, ENZO is killed by police; his final vision is something vaguely human in a cheap tuxedo, its painted-on face drifting closer.</p>
         </div>
         <div class="card">
-          <p class="caption">Act II &mdash; Stations</p>
-          <p>Hill tracks a cult of mourners who stage miracles for a hidden audience of the bereaved. Each interrogation unfolds like a confessional, exposing Hill&rsquo;s buried guilt and opening seams between memory and the waking world.</p>
+          <p class="caption">II. The Strange Case of Norma Agnes Linwood</p>
+          <p>Jolted from a fevered nightmare, DAVID responds to NORMA, a middle-aged woman who cannot find her elderly mother. The decaying house mirrors his dream. NORMA is unkempt, terrified, and as the officers depart she stares at an upstairs window in pure horror. Alone, she tends to her mother&rsquo;s hidden, decaying body, applying makeup and brushing her hair each day. When NORMA calls to confess, she hallucinates TUXEDO MAN across from her, seizes, and is hospitalized. DAVID suspects mercy, not malice. Her last words before flatlining: &ldquo;Are you feeling better, mommy?&rdquo;</p>
         </div>
         <div class="card">
-          <p class="caption">Act III &mdash; Golgotha</p>
-          <p>With the city plunged into blackout, Hill descends into catacombs beneath a derelict cathedral. The final revelation forces him to confront a choice: resurrect the past at a terrible price, or accept loss and end the cycle of ritual bloodshed.</p>
+          <p class="caption">III. David Goes Home</p>
+          <p>DAVID is called to 616 Freeman Avenue &mdash; the BURROW&rsquo;S House he believed burned down decades ago. In the yard rests his dead mother&rsquo;s severed hand, still as young as the day she died thirty years earlier. He steps inside without hesitation, following bloody handprints lining the hall toward a closed door that promises a revelation beyond imagination.</p>
         </div>
       </div>
     </section>

--- a/story.html
+++ b/story.html
@@ -34,20 +34,33 @@
   </header>
 
   <main>
-    <section class="section">
-      <div class="overline">Story</div>
-      <h1>Three Acts inside a haunted metropolis.</h1>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Story</div>
+        <h1>Three acts inside a haunted metropolis.</h1>
+        <p>Detective David Hill&rsquo;s investigation bends grief into ritual. Each act escalates the collision between faith, memory, and the city&rsquo;s secret congregation of mourners.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">Feature Narrative</span>
+        <div class="status-panel">
+          <p class="caption">Running Themes</p>
+          <p>Resurrection myths, corrupted sacraments, and the cost of bargaining with the past.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
       <div class="grid cards" style="margin-top:3rem;">
         <div class="card">
-          <p class="caption">Act I — The Wake</p>
+          <p class="caption">Act I &mdash; The Wake</p>
           <p>Detective David Hill is assigned to a ritualistic murder that mirrors the unsolved death of his wife. Visions surge through sodium-lit rain and stained glass as Hill meets a prophetic child who sketches crime scenes before they occur.</p>
         </div>
         <div class="card">
-          <p class="caption">Act II — Stations</p>
+          <p class="caption">Act II &mdash; Stations</p>
           <p>Hill tracks a cult of mourners who stage miracles for a hidden audience of the bereaved. Each interrogation unfolds like a confessional, exposing Hill&rsquo;s buried guilt and opening seams between memory and the waking world.</p>
         </div>
         <div class="card">
-          <p class="caption">Act III — Golgotha</p>
+          <p class="caption">Act III &mdash; Golgotha</p>
           <p>With the city plunged into blackout, Hill descends into catacombs beneath a derelict cathedral. The final revelation forces him to confront a choice: resurrect the past at a terrible price, or accept loss and end the cycle of ritual bloodshed.</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- build a noir-inspired static site for Golgotha with multi-page navigation, hero messaging, and financing CTAs
- add placeholder content for story, director, cast & crew, gallery, press, screenings, investors, and contact sections aligned with KPIs
- implement shared styling and a text-based SVG poster used for Open Graph previews

## Testing
- No automated tests (static HTML site)


------
https://chatgpt.com/codex/tasks/task_b_68d9f12573c48331887782f9cfb0d6b9