### PR TITLE
Add Golgotha poster art and hover flip interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Golgotha-Website
+# Golgotha Website
+
+Static marketing site for the feature film **Golgotha**, a poetic horror-noir about Detective David Hill confronting grief, faith, and supernatural crime. The site is optimized to cultivate financing conversations, audience signups, and supporter donations.
+
+## Structure
+
+- `index.html` &mdash; Homepage hero, KPIs, and momentum overview.
+- `story.html` &mdash; Three-act synopsis.
+- `director.html` &mdash; Director's statement.
+- `cast-crew.html` &mdash; Placeholder cast and crew bios.
+- `gallery.html` &mdash; Mood still placeholders.
+- `press.html` &mdash; Press status.
+- `screenings.html` &mdash; Screening updates.
+- `investors.html` &mdash; Financing overview, KPIs, and CTAs.
+- `contact.html` &mdash; Contact form and production office details.
+- `assets/css/main.css` &mdash; Shared noir-inspired styling.
+- `public/poster-og-placeholder.svg` &mdash; Text-based poster placeholder used for open graph metadata.
+
+## Local Preview
+
+Open any of the HTML files directly in a browser or serve the directory with a simple HTTP server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000/`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Golgotha-Website

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,1001 @@
+:root {
+  --bg-primary: #050505;
+  --bg-secondary: #0b0b0b;
+  --bg-elevated: rgba(233, 230, 223, 0.03);
+  --bg-contrast: rgba(139, 15, 15, 0.08);
+  --text-primary: #e9e6df;
+  --text-muted: rgba(233, 230, 223, 0.65);
+  --accent: #8b0f0f;
+  --accent-hot: #c51f1f;
+  --accent-soft: rgba(139, 15, 15, 0.35);
+  --accent-glow: rgba(197, 31, 31, 0.4);
+  --max-width: 1120px;
+  --font-heading: "Archivo Condensed", "Impact", "Haettenschweiler", "Arial Narrow", sans-serif;
+  --font-body: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", "Consolas", monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(197, 31, 31, 0.16), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(104, 12, 12, 0.24), transparent 60%),
+    radial-gradient(circle at 50% 80%, rgba(197, 31, 31, 0.12), transparent 50%);
+  pointer-events: none;
+  opacity: 0.9;
+  z-index: 0;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: -200px;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.1' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.22'/%3E%3C/svg%3E");
+  mix-blend-mode: screen;
+  animation: grain 14s steps(10) infinite;
+  z-index: 1;
+  opacity: 0.18;
+}
+
+@keyframes grain {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(-10px, 10px, 0);
+  }
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(12px);
+  background: rgba(5, 5, 5, 0.92);
+  border-bottom: 1px solid rgba(233, 230, 223, 0.08);
+}
+
+header::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -1px 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(197, 31, 31, 0.6), transparent);
+}
+
+.nav-container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1.35rem 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.brand {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 1.35rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  position: relative;
+}
+
+.brand::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.3rem;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent-hot), transparent);
+  opacity: 0.6;
+}
+
+nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1.5rem;
+  justify-content: flex-end;
+}
+
+nav a {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.74rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 0.35rem;
+  transition: color 180ms ease;
+}
+
+nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--accent-hot));
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform 200ms ease;
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--text-primary);
+}
+
+nav a:hover::after,
+nav a:focus::after,
+nav a[aria-current="page"]::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+main {
+  flex: 1;
+  position: relative;
+  z-index: 2;
+}
+
+.section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 5rem 1.75rem;
+  position: relative;
+}
+
+.section::before {
+  content: "";
+  position: absolute;
+  inset: 1.5rem;
+  border: 1px solid rgba(233, 230, 223, 0.05);
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.section:hover::before {
+  opacity: 1;
+}
+
+.section--contrast {
+  background: linear-gradient(135deg, rgba(139, 15, 15, 0.08), rgba(5, 5, 5, 0.65));
+  border-radius: 20px;
+  padding: 5rem clamp(1.5rem, 6vw, 4rem);
+  overflow: hidden;
+}
+
+.section--overlay {
+  background: rgba(11, 11, 11, 0.7);
+  border-radius: 20px;
+  backdrop-filter: blur(6px);
+  padding: 5rem clamp(1.5rem, 6vw, 4rem);
+}
+
+.section--tight {
+  padding-top: 3.5rem;
+  padding-bottom: 3.5rem;
+}
+
+.overline {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.overline::before {
+  content: "";
+  width: 32px;
+  height: 1px;
+  background: linear-gradient(90deg, var(--accent-hot), transparent);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.75rem;
+  color: var(--text-primary);
+}
+
+h1 {
+  font-size: clamp(3rem, 7vw, 5rem);
+  line-height: 1.02;
+}
+
+h2 {
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1.1;
+}
+
+p {
+  line-height: 1.7;
+  max-width: 76ch;
+  color: rgba(233, 230, 223, 0.9);
+}
+
+p.caption {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+a {
+  color: var(--accent-hot);
+}
+
+a.button,
+button.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  padding: 0.95rem 1.6rem;
+  border: 1px solid rgba(197, 31, 31, 0.6);
+  color: var(--text-primary);
+  text-decoration: none;
+  text-transform: uppercase;
+  font-family: var(--font-heading);
+  letter-spacing: 0.24em;
+  background: linear-gradient(135deg, rgba(139, 15, 15, 0.75), rgba(139, 15, 15, 0.35));
+  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+  border-radius: 999px;
+  position: relative;
+  overflow: hidden;
+}
+
+a.button::after,
+button.button::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(233, 230, 223, 0.12), transparent 55%);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+a.button:hover,
+button.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(197, 31, 31, 0.3);
+}
+
+a.button:hover::after,
+button.button:hover::after {
+  opacity: 1;
+}
+
+.hero {
+  display: grid;
+  gap: clamp(2.5rem, 6vw, 4.5rem);
+  grid-template-columns: minmax(280px, 1.35fr) minmax(220px, 1fr);
+  align-items: stretch;
+  min-height: calc(100vh - 140px);
+}
+
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.hero-lede {
+  font-size: 1.05rem;
+  color: rgba(233, 230, 223, 0.85);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.62rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(233, 230, 223, 0.18);
+  color: var(--text-muted);
+}
+
+.badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-hot);
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+
+.badge--glow {
+  background: rgba(197, 31, 31, 0.14);
+  border-color: rgba(197, 31, 31, 0.6);
+  color: var(--text-primary);
+}
+
+.badge--outline {
+  background: transparent;
+  border-style: dashed;
+}
+
+.hero-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+}
+
+.hero-media {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px solid rgba(233, 230, 223, 0.1);
+  border-radius: 20px;
+  background: linear-gradient(160deg, rgba(139, 15, 15, 0.4), rgba(5, 5, 5, 0.85));
+  overflow: hidden;
+}
+
+.hero-media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 20%, rgba(233, 230, 223, 0.08), transparent 60%);
+  pointer-events: none;
+}
+
+.hero-frame {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.9rem;
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  border-radius: 14px;
+  padding: 1.5rem;
+  background: rgba(5, 5, 5, 0.6);
+  margin-bottom: 1.5rem;
+}
+
+.hero-poster {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 4.4;
+  perspective: 1200px;
+}
+
+.hero-poster--interactive {
+  cursor: pointer;
+}
+
+.hero-poster--interactive:focus-visible {
+  outline: 2px solid rgba(197, 31, 31, 0.65);
+  outline-offset: 6px;
+}
+
+.hero-poster__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(233, 230, 223, 0.22);
+  overflow: hidden;
+  transform-style: preserve-3d;
+  transition: transform 520ms ease;
+  box-shadow: 0 28px 45px rgba(0, 0, 0, 0.45);
+}
+
+.hero-poster--interactive:hover .hero-poster__inner,
+.hero-poster--interactive:focus-within .hero-poster__inner {
+  transform: rotateY(180deg);
+}
+
+.hero-poster__face {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  backface-visibility: hidden;
+  display: block;
+}
+
+.hero-poster__face--back {
+  transform: rotateY(180deg);
+}
+
+.hero-poster__note {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.62rem;
+  color: rgba(233, 230, 223, 0.55);
+  text-align: center;
+}
+
+.grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.two-column {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.cards {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  position: relative;
+  border: 1px solid rgba(233, 230, 223, 0.08);
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+  background: linear-gradient(150deg, rgba(233, 230, 223, 0.06), rgba(5, 5, 5, 0.7));
+  border-radius: 18px;
+  overflow: hidden;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border: 1px solid rgba(197, 31, 31, 0.18);
+  border-radius: 16px;
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 30%, rgba(197, 31, 31, 0.18));
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 16px 45px rgba(197, 31, 31, 0.18);
+}
+
+.card:hover::before,
+.card:hover::after {
+  opacity: 1;
+}
+
+.card h3 {
+  margin-top: 0.8rem;
+}
+
+blockquote {
+  margin: 0;
+  padding: 2.2rem 2.4rem;
+  border-left: 2px solid var(--accent-hot);
+  background: rgba(139, 15, 15, 0.08);
+  border-radius: 16px;
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2.4rem;
+}
+
+.profile-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-radius: 20px;
+  border: 1px solid rgba(233, 230, 223, 0.14);
+  padding: 1.75rem;
+  background: linear-gradient(155deg, rgba(11, 11, 11, 0.9), rgba(139, 15, 15, 0.1));
+  box-shadow: inset 0 1px 0 rgba(233, 230, 223, 0.06);
+  transition: transform 260ms ease, border-color 260ms ease, box-shadow 260ms ease;
+}
+
+.profile-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(233, 230, 223, 0.04);
+  pointer-events: none;
+}
+
+.profile-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(139, 15, 15, 0.6);
+  box-shadow: 0 18px 40px rgba(11, 11, 11, 0.6);
+}
+
+.profile-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.profile-card__media {
+  border-radius: 14px;
+  overflow: hidden;
+  aspect-ratio: 3 / 4;
+  margin-bottom: 1.5rem;
+  border: 1px solid rgba(233, 230, 223, 0.18);
+  background: rgba(233, 230, 223, 0.03);
+}
+
+.profile-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  filter: contrast(95%) saturate(85%);
+}
+
+.profile-card__role {
+  font-family: var(--font-mono);
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: rgba(233, 230, 223, 0.6);
+  margin-bottom: 0.4rem;
+}
+
+.profile-card h3 {
+  font-size: clamp(1.35rem, 1.4vw + 0.9rem, 1.6rem);
+  margin-bottom: 0.9rem;
+}
+
+.profile-card p {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.6;
+}
+
+.section-intro {
+  max-width: 620px;
+  margin-top: 1.2rem;
+  font-size: 1.05rem;
+  color: rgba(233, 230, 223, 0.78);
+}
+
+.casting-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.6rem;
+}
+
+.role-card {
+  position: relative;
+  padding: 1.6rem;
+  border-radius: 18px;
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  background: linear-gradient(160deg, rgba(233, 230, 223, 0.08), rgba(11, 11, 11, 0.75));
+  box-shadow: inset 0 1px 0 rgba(233, 230, 223, 0.08);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
+
+.role-card__title {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.role-card__subtitle {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(233, 230, 223, 0.62);
+  margin: 0;
+}
+
+.role-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+}
+
+.poster-duo {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+  margin-bottom: 2.5rem;
+}
+
+.gallery-item {
+  border: 1px solid rgba(233, 230, 223, 0.1);
+  border-radius: 16px;
+  padding: 1.6rem;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background: linear-gradient(150deg, rgba(233, 230, 223, 0.05), rgba(5, 5, 5, 0.75));
+  position: relative;
+  overflow: hidden;
+}
+
+.gallery-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 35%, rgba(197, 31, 31, 0.22));
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.gallery-item:hover::after {
+  opacity: 1;
+}
+
+.gallery-item--image {
+  padding: 0;
+  min-height: 0;
+  display: block;
+}
+
+.gallery-item--image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-item--image figcaption {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 1.1rem 1.25rem;
+  background: linear-gradient(180deg, transparent, rgba(5, 5, 5, 0.86));
+  font-family: var(--font-mono);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  color: rgba(233, 230, 223, 0.78);
+  text-align: left;
+}
+
+.gallery-item span {
+  font-family: var(--font-mono);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: rgba(233, 230, 223, 0.6);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 2.5rem;
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid rgba(233, 230, 223, 0.08);
+  padding: 1.25rem 1.5rem;
+  text-align: left;
+  background: rgba(11, 11, 11, 0.8);
+}
+
+.table th {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.8rem;
+  background: rgba(139, 15, 15, 0.22);
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1.8rem;
+}
+
+label {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+input,
+textarea {
+  background: rgba(233, 230, 223, 0.06);
+  border: 1px solid rgba(233, 230, 223, 0.12);
+  padding: 1rem 1.1rem;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  border-radius: 12px;
+  transition: border 180ms ease, box-shadow 180ms ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(197, 31, 31, 0.8);
+  box-shadow: 0 0 0 3px rgba(197, 31, 31, 0.18);
+}
+
+textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.page-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(2rem, 5vw, 3.5rem);
+  align-items: end;
+  padding-bottom: 4rem;
+  border-bottom: 1px solid rgba(233, 230, 223, 0.08);
+}
+
+.page-hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-hero__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.poster-stack {
+  position: relative;
+  width: min(200px, 42vw);
+  aspect-ratio: 3 / 4.4;
+  display: block;
+}
+
+.poster-stack:focus-visible {
+  outline: 2px solid rgba(197, 31, 31, 0.5);
+  outline-offset: 6px;
+}
+
+.poster-stack__poster {
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(233, 230, 223, 0.18);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.4);
+  transition: transform 240ms ease, box-shadow 240ms ease;
+}
+
+.poster-stack__poster img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.poster-stack__poster--front {
+  transform: rotate(2deg) translateY(-6px);
+  z-index: 2;
+}
+
+.poster-stack__poster--back {
+  transform: rotate(-6deg) translate(-14px, 18px);
+  z-index: 1;
+  opacity: 0.9;
+}
+
+.poster-stack:hover .poster-stack__poster--front,
+.poster-stack:focus-within .poster-stack__poster--front {
+  transform: rotate(0deg) translateY(-2px);
+  box-shadow: 0 22px 40px rgba(0, 0, 0, 0.5);
+}
+
+.poster-stack:hover .poster-stack__poster--back,
+.poster-stack:focus-within .poster-stack__poster--back {
+  transform: rotate(-3deg) translate(-8px, 12px);
+  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.45);
+}
+
+.list-soft {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.list-soft li {
+  position: relative;
+  padding-left: 1.5rem;
+  color: rgba(233, 230, 223, 0.88);
+}
+
+.list-soft li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-hot);
+  box-shadow: 0 0 12px rgba(197, 31, 31, 0.5);
+}
+
+.status-panel {
+  border: 1px solid rgba(233, 230, 223, 0.08);
+  border-radius: 18px;
+  padding: 1.8rem;
+  background: rgba(5, 5, 5, 0.78);
+  display: grid;
+  gap: 0.8rem;
+}
+
+.status-panel strong {
+  font-family: var(--font-heading);
+  letter-spacing: 0.14em;
+}
+
+.address-block {
+  font-family: var(--font-mono);
+  letter-spacing: 0.18em;
+  font-size: 0.68rem;
+  color: rgba(233, 230, 223, 0.72);
+  line-height: 1.8;
+  text-transform: uppercase;
+}
+
+footer {
+  border-top: 1px solid rgba(233, 230, 223, 0.08);
+  padding: 2.75rem 1.5rem;
+  text-align: center;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: rgba(233, 230, 223, 0.6);
+  position: relative;
+}
+
+footer::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 140px;
+  height: 1px;
+  transform: translateX(-50%);
+  background: linear-gradient(90deg, transparent, rgba(197, 31, 31, 0.7), transparent);
+}
+
+@media (max-width: 960px) {
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: unset;
+  }
+
+  .hero-media {
+    order: -1;
+  }
+
+  .section::before {
+    inset: 1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  nav {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .section {
+    padding: 4rem 1.25rem;
+  }
+
+  .section--contrast,
+  .section--overlay {
+    padding: 4rem 1.5rem;
+  }
+
+  .overline::before {
+    display: none;
+  }
+
+  .badge {
+    letter-spacing: 0.18em;
+  }
+}

--- a/cast-crew.html
+++ b/cast-crew.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cast &amp; Crew — Golgotha</title>
+  <meta name="description" content="Meet the cast and crew assembling the feature film Golgotha.">
+  <meta property="og:title" content="Cast &amp; Crew — Golgotha">
+  <meta property="og:description" content="Placeholder bios for the cast and crew of Golgotha.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/cast-crew.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html" aria-current="page">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Cast &amp; Crew</div>
+        <h1>Performers inhabiting the dream.</h1>
+        <p>We assemble a company of actors and artisans who understand Golgotha&rsquo;s blend of noir minimalism and supernatural fervor.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">In Conversation with Talent</span>
+        <div class="poster-stack" tabindex="0" aria-label="Golgotha teaser posters">
+          <div class="poster-stack__poster poster-stack__poster--front">
+            <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross">
+          </div>
+          <div class="poster-stack__poster poster-stack__poster--back">
+            <img src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+          </div>
+        </div>
+        <div class="status-panel">
+          <p class="caption">Focus</p>
+          <p>Faces etched with loss. Hands fluent in ritual. Collaborators who treat genre as elevated ceremony.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--contrast">
+      <div class="overline">Creative Collective</div>
+      <h2>Profiles from the Golgotha company.</h2>
+      <p class="section-intro">Seasoned collaborators from the horror, festival, and arthouse circuits steer Golgotha&rsquo;s ritual with precision and empathy.</p>
+      <div class="team-grid" style="margin-top:3rem;">
+        <article class="profile-card">
+          <figure class="profile-card__media">
+            <img src="public/team/christopher-rosica.svg" alt="Stylized portrait placeholder for Christopher Rosica">
+          </figure>
+          <div class="profile-card__body">
+            <p class="profile-card__role">Director</p>
+            <h3>Christopher Rosica</h3>
+            <p>Christopher Rosica is a filmmaker whose work has premiered at Slamdance, Indie Memphis, and the New Orleans Film Festival. He was a finalist for the Museum of the Moving Image&rsquo;s Sloan Science in Cinema grant and the Louisiana Film Prize, and his short <em>It Was Kind of a Love Story</em> (2024) advanced through the New Orleans Film Festival Pitch Forum and the Stowe Story Labs / NOFS Narrative Lab.</p>
+          </div>
+        </article>
+        <article class="profile-card">
+          <figure class="profile-card__media">
+            <img src="public/team/grace-caroline-curley.svg" alt="Stylized portrait placeholder for Grace Caroline Curley">
+          </figure>
+          <div class="profile-card__body">
+            <p class="profile-card__role">Screenwriter</p>
+            <h3>Grace Caroline Curley</h3>
+            <p>Grace Caroline Curley is an award-winning screenwriter and playwright based in New Orleans. Her short <em>The Great Void</em> (2024) premiered at FilmQuest, where it received Best Ensemble, and she has presented work with the Voodoo Mystery Symposium, the Tennessee Williams Literary Festival, and the Miskatonic Institute of Horror Studies.</p>
+          </div>
+        </article>
+        <article class="profile-card">
+          <figure class="profile-card__media">
+            <img src="public/team/daniel-oakley.svg" alt="Stylized portrait placeholder for Daniel Oakley">
+          </figure>
+          <div class="profile-card__body">
+            <p class="profile-card__role">Casting Director</p>
+            <h3>Daniel Oakley</h3>
+            <p>Daniel Oakley is a graduate of Circle in the Square Theatre School in New York City. He has coached performers alongside Philip Seymour Hoffman, Kevin Bacon, and Lady Gaga, and co-founded The Oakley Collective to unite actors and directors as collaborators.</p>
+          </div>
+        </article>
+        <article class="profile-card">
+          <figure class="profile-card__media">
+            <img src="public/team/ethan-beller.svg" alt="Stylized portrait placeholder for Ethan Beller">
+          </figure>
+          <div class="profile-card__body">
+            <p class="profile-card__role">Lead Producer</p>
+            <h3>Ethan Beller</h3>
+            <p>Ethan Beller is an Atlanta-based producer and frequent collaborator of Rosica&rsquo;s. His work spans Vice, ESPN, AMC Networks, and a range of boutique features, pairing financing strategy with distribution and impact campaign expertise.</p>
+          </div>
+        </article>
+        <article class="profile-card">
+          <figure class="profile-card__media">
+            <img src="public/team/faith-nicholas.svg" alt="Stylized portrait placeholder for Faith Nicholas">
+          </figure>
+          <div class="profile-card__body">
+            <p class="profile-card__role">Associate Producer</p>
+            <h3>Faith Nicholas</h3>
+            <p>Faith Nicholas is a producer based in New York City. She has supported emerging horror voices across IFC Films, Broadway Video, and Screambox, and shares development insights with a community of more than 25,000 genre fans on TikTok.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section section--overlay">
+      <div class="overline">Casting Outlook</div>
+      <h2>Key roles in active conversations.</h2>
+      <div class="casting-grid" style="margin-top:3rem;">
+        <article class="role-card">
+          <div>
+            <p class="role-card__subtitle">Lead</p>
+            <h3 class="role-card__title">Detective David Hill</h3>
+          </div>
+          <p>We&rsquo;re pursuing performers with arthouse credibility and emotionally restrained gravitas to embody David&rsquo;s haunted resolve.</p>
+        </article>
+        <article class="role-card">
+          <div>
+            <p class="role-card__subtitle">Antagonist</p>
+            <h3 class="role-card__title">The Tuxedo Man</h3>
+          </div>
+          <p>A spectral presence demanding physical theater backgrounds and an ability to communicate dread through minimal gesture.</p>
+        </article>
+        <article class="role-card">
+          <div>
+            <p class="role-card__subtitle">Supporting</p>
+            <h3 class="role-card__title">Norma Agnes Linwood</h3>
+          </div>
+          <p>This role requires a veteran actor capable of navigating psychological horror with compassion, fragility, and menace.</p>
+        </article>
+        <article class="role-card">
+          <div>
+            <p class="role-card__subtitle">Ensemble</p>
+            <h3 class="role-card__title">The Burrow Family</h3>
+          </div>
+          <p>Seeking character actors with distinctive silhouettes and vocal textures to populate the Burrow house&rsquo;s living gallery.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact — Golgotha</title>
+  <meta name="description" content="Contact the Golgotha team for partnerships, press, and support.">
+  <meta property="og:title" content="Contact — Golgotha">
+  <meta property="og:description" content="Reach the Golgotha team for investor calls, press, and collaborations.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/contact.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html" aria-current="page">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Contact</div>
+        <h1>Enter the investigation.</h1>
+        <p>Reach the Golgotha team for investor conversations, press coordination, or to join the audience of early believers.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--glow">Response within 48 hours</span>
+        <div class="poster-stack" tabindex="0" aria-label="Golgotha teaser posters">
+          <div class="poster-stack__poster poster-stack__poster--front">
+            <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross">
+          </div>
+          <div class="poster-stack__poster poster-stack__poster--back">
+            <img src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+          </div>
+        </div>
+        <div class="status-panel">
+          <p class="caption">Direct Email</p>
+          <a class="button" href="mailto:hello@golgothafilm.com">hello@golgothafilm.com</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--overlay">
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <form>
+            <div class="form-group">
+              <label for="name">Name</label>
+              <input id="name" name="name" type="text" placeholder="Your Name">
+            </div>
+            <div class="form-group">
+              <label for="email">Email</label>
+              <input id="email" name="email" type="email" placeholder="you@example.com">
+            </div>
+            <div class="form-group">
+              <label for="message">Message</label>
+              <textarea id="message" name="message" placeholder="Tell us how you&rsquo;d like to collaborate."></textarea>
+            </div>
+            <button class="button" type="submit">Send Message</button>
+          </form>
+        </div>
+        <div>
+          <p class="caption">Studio Address</p>
+          <div class="address-block">
+            Golgotha Film<br>
+            1111 Noir Avenue<br>
+            Los Angeles, CA 90001
+          </div>
+          <p style="margin-top:2rem;">We coordinate investor calls via Cal.com and release production notes through Buttondown. Subscribe on the homepage for updates.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/director.html
+++ b/director.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Director — Golgotha</title>
+  <meta name="description" content="Director's statement for Golgotha, a poetic horror-noir feature film.">
+  <meta property="og:title" content="Director — Golgotha">
+  <meta property="og:description" content="The director of Golgotha treats horror as poetry, orchestrating grief, faith, and memory.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/director.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html" aria-current="page">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Director&rsquo;s Statement</div>
+        <h1>Horror as poetry, memory as scripture.</h1>
+        <p>I direct Golgotha as a visual symphony, treating dread like a composition of silence, ritual, and sudden light. Each frame leans into the tension between brutal reality and metaphysical suggestion.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--glow">Writer / Director</span>
+        <div class="poster-stack" tabindex="0" aria-label="Golgotha teaser posters">
+          <div class="poster-stack__poster poster-stack__poster--front">
+            <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross">
+          </div>
+          <div class="poster-stack__poster poster-stack__poster--back">
+            <img src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+          </div>
+        </div>
+        <div class="status-panel">
+          <p class="caption">Influences</p>
+          <ul class="list-soft">
+            <li>David Lynch&rsquo;s dream-logic</li>
+            <li>Robert Eggers&rsquo;s devotion to ritual</li>
+            <li>Ari Aster&rsquo;s psychological excavation</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <p>Cinema is made of the fabric of the universe &mdash; light, sound, and time. Therefore, it is the perfect art form to tell a story with such existential weight. My approach to filmmaking is a little different than some. My background is in the avant-garde, and so I like to think of a film as something between a moving painting and a symphony.</p>
+          <p>Every single shot must be handled with the same attention to detail that an artist would bring to a canvas. Every frame must be a painting. Anything in the frame, from the colors to the lighting, blocking, and movement, can shift the mood of an image ever so slightly.</p>
+        </div>
+        <div>
+          <p>Think about how different musical notes fit together to make a chord with its own distinct emotional value. That&rsquo;s a shot &mdash; a series of small visual decisions that converge to express a distinct emotion. In music, chords are arranged amidst other chords to create a piece of music. That is editing: comparing images together to create a fluid and dynamic emotional flow. That is cinema.</p>
+          <p>A visual symphony.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/gallery.html
+++ b/gallery.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gallery — Golgotha</title>
+  <meta name="description" content="Placeholder stills for the feature film Golgotha.">
+  <meta property="og:title" content="Gallery — Golgotha">
+  <meta property="og:description" content="Explore twelve placeholder stills capturing Golgotha&rsquo;s mood.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/gallery.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html" aria-current="page">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Gallery</div>
+        <h1>Atmospheric stills &mdash; arriving soon.</h1>
+        <p>Twelve frames capturing Golgotha&rsquo;s palette of bloodlight, fog, and cathedral shadows. Each still is a placeholder, a promise of the visual fever dream in production.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">Lookbook In Development</span>
+        <div class="poster-stack" tabindex="0" aria-label="Golgotha teaser posters">
+          <div class="poster-stack__poster poster-stack__poster--front">
+            <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross">
+          </div>
+          <div class="poster-stack__poster poster-stack__poster--back">
+            <img src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+          </div>
+        </div>
+        <div class="status-panel">
+          <p class="caption">Visual Motifs</p>
+          <ul class="list-soft">
+            <li>35mm grain &amp; analog flares</li>
+            <li>Candlelit sanctuaries</li>
+            <li>Rain-soaked neon corridors</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="poster-duo">
+        <figure class="gallery-item gallery-item--image">
+          <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross" loading="lazy">
+          <figcaption>Poster 01 &mdash; Fingerprint Cross</figcaption>
+        </figure>
+        <figure class="gallery-item gallery-item--image">
+          <img src="public/posters/golgotha-poster-2.svg" alt="Golgotha poster with skeletal hand and crimson title" loading="lazy">
+          <figcaption>Poster 02 &mdash; Mommy Loves You</figcaption>
+        </figure>
+      </div>
+      <div class="gallery-grid">
+        <div class="gallery-item"><span>Still 01 &mdash; Alley of Echoes</span></div>
+        <div class="gallery-item"><span>Still 02 &mdash; Chapel Vigil</span></div>
+        <div class="gallery-item"><span>Still 03 &mdash; Evidence Shrine</span></div>
+        <div class="gallery-item"><span>Still 04 &mdash; The Red Phone</span></div>
+        <div class="gallery-item"><span>Still 05 &mdash; Rainlit Confession</span></div>
+        <div class="gallery-item"><span>Still 06 &mdash; Cathedral Steps</span></div>
+        <div class="gallery-item"><span>Still 07 &mdash; Midnight Procession</span></div>
+        <div class="gallery-item"><span>Still 08 &mdash; Station Ghosts</span></div>
+        <div class="gallery-item"><span>Still 09 &mdash; Flicker Room</span></div>
+        <div class="gallery-item"><span>Still 10 &mdash; Tunnel Hymn</span></div>
+        <div class="gallery-item"><span>Still 11 &mdash; Relic Archive</span></div>
+        <div class="gallery-item"><span>Still 12 &mdash; Dawn Anointing</span></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Golgotha — A Poetic Horror-Noir Feature Film</title>
+  <meta name="description" content="DAVID HILL, a jaded detective, wrestles with existential angst while investigating surreal and supernatural crimes.">
+  <meta property="og:title" content="Golgotha — Poetic Horror-Noir Feature Film">
+  <meta property="og:description" content="DAVID HILL, a jaded detective, wrestles with existential angst while investigating surreal and supernatural crimes.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html" aria-current="page">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section hero">
+      <div class="hero-content">
+        <div class="overline">Feature Film / Horror Noir</div>
+        <h1>DAVID HILL, a jaded detective, wrestles with existential angst as he investigates a series of increasingly surreal and supernatural crimes.</h1>
+        <p class="hero-lede">Golgotha draws on the cinematic lineage of David Lynch, Robert Eggers, and Ari Aster to fuse arthouse restraint with midnight dread. Investors and audiences are invited into a poetic investigation where grief, faith, and memory echo through sodium-lit rain and candlelit sanctuaries.</p>
+        <div class="hero-actions">
+          <a class="button" href="investors.html#deck">View Investor Overview</a>
+          <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule a Call</a>
+          <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Support via Stripe</a>
+        </div>
+        <div class="hero-meta">
+          <span class="badge badge--glow">Now Packaging — Financing &amp; Audience Building</span>
+          <span>Phase: In Casting &amp; Pre-Production</span>
+          <span>Raise Target: $100K Development / Packaging</span>
+        </div>
+      </div>
+      <div class="hero-media">
+        <div class="hero-frame">
+          <div class="hero-poster hero-poster--interactive" tabindex="0" aria-label="Golgotha key art — hover or focus to reveal alternate poster">
+            <div class="hero-poster__inner">
+              <img class="hero-poster__face" src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross and crimson title">
+              <img class="hero-poster__face hero-poster__face--back" src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+            </div>
+          </div>
+          <p class="hero-poster__note">Hover or focus to reveal alternate key art</p>
+        </div>
+        <div class="status-panel">
+          <p class="caption">Investment Hooks</p>
+          <strong>Elevated horror noir</strong>
+          <p>Psychological dread, cathedral-scale visuals, and a director treating horror as whispered poetry.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--contrast">
+      <div class="overline">Momentum</div>
+      <h2>Signals investors are watching.</h2>
+      <p class="hero-lede">Our packaging sprint positions Golgotha to capture financing while cultivating an obsessive audience.</p>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <p class="caption">Primary Goal</p>
+          <p>Secure financing partners and early believers who resonate with Golgotha&rsquo;s austere, lyrical vision.</p>
+        </div>
+        <div>
+          <p class="caption">Secondary Goal</p>
+          <p>Activate an audience who follows Detective Hill&rsquo;s descent through our newsletters, screenings, and supporter community.</p>
+        </div>
+      </div>
+      <div class="grid cards" style="margin-top:2.5rem;">
+        <div class="card">
+          <p class="caption">KPI: Email Signups</p>
+          <h3>Gather the faithful</h3>
+          <p>Subscribe to the Buttondown dispatch to receive updates from the Golgotha investigation room.</p>
+          <a class="button" href="https://buttondown.email/" target="_blank" rel="noopener">Join Buttondown</a>
+        </div>
+        <div class="card">
+          <p class="caption">KPI: Investor Meetings</p>
+          <h3>Enter the briefing</h3>
+          <p>Schedule a private session via Cal.com to review our materials, production plan, and financial strategy.</p>
+          <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Book via Cal.com</a>
+        </div>
+        <div class="card">
+          <p class="caption">KPI: Donations</p>
+          <h3>Underwrite the hunt</h3>
+          <p>Support the development phase with a Stripe Checkout contribution. Donations are not equity investments.</p>
+          <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Stripe Checkout</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--overlay">
+      <div class="overline">Atmosphere</div>
+      <h2>A devotion to cinematic dread.</h2>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <p>Industrial fog, sodium-lit rain, and candlelit chapels. Golgotha merges the intimacy of a psychological confessional with the suspense of a nightmare procedural. The film translates grief into images: flickering projector light, slow-motion ash, whispered hymns inside abandoned stations.</p>
+        </div>
+        <div>
+          <blockquote>
+            Horror is the liturgy, noir is the confessional booth. Detective Hill is both penitent and sinner, translating unspeakable loss into ritual justice.
+          </blockquote>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="overline">Audience</div>
+      <h2>Who we&rsquo;re calling into the dark.</h2>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <ul class="list-soft">
+            <li>Tarkovsky devotees with an appetite for horror</li>
+            <li>Fans of David Lynch&rsquo;s dream-logic investigations</li>
+            <li>Giallo aficionados craving artful dread</li>
+          </ul>
+        </div>
+        <div>
+          <ul class="list-soft">
+            <li>College-educated Millennials and Gen Z drawn to the arts</li>
+            <li>Collectors of boutique physical media releases</li>
+            <li>Visual artists, poets, photographers, and painters</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/investors.html
+++ b/investors.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Investors — Golgotha</title>
+  <meta name="description" content="Investor overview for the feature film Golgotha.">
+  <meta property="og:title" content="Investors — Golgotha">
+  <meta property="og:description" content="Review the investor overview, deck request, and support options for Golgotha.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/investors.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html" aria-current="page">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section page-hero" id="deck">
+      <div class="page-hero__content">
+        <div class="overline">Investors</div>
+        <h1>A precision plan for a $100K raise.</h1>
+        <p>Golgotha is entering casting and pre-production with a development target of <strong>$100,000</strong>. We invite equity partners, executive producers, and patrons aligned with elevated genre filmmaking to help package the film.</p>
+        <div class="hero-actions">
+          <a class="button" href="mailto:hello@golgothafilm.com?subject=Golgotha%20Deck%20Request">Request the Deck</a>
+          <a class="button" href="https://cal.com/" target="_blank" rel="noopener">Schedule an Investor Call</a>
+          <a class="button" href="https://buy.stripe.com/" target="_blank" rel="noopener">Support via Stripe</a>
+        </div>
+        <p class="caption">Donations via Stripe are not investments and may be tax-deductible only if routed through a fiscal sponsor.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--glow">Status &mdash; In Casting &amp; Pre-Production</span>
+        <div class="poster-stack" tabindex="0" aria-label="Golgotha teaser posters">
+          <div class="poster-stack__poster poster-stack__poster--front">
+            <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross">
+          </div>
+          <div class="poster-stack__poster poster-stack__poster--back">
+            <img src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+          </div>
+        </div>
+        <div class="status-panel">
+          <p class="caption">Snapshot</p>
+          <ul class="list-soft">
+            <li>Budget tiers designed for scalable expansion</li>
+            <li>Prestige genre festival and sales roadmap</li>
+            <li>Seasoned department heads from horror &amp; noir</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--contrast">
+      <div class="overline">Key Performance Indicators</div>
+      <h2>Leading metrics guiding the raise.</h2>
+      <p class="hero-lede">Audience traction and investor interest are measured through three priority channels.</p>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th>Focus</th>
+            <th>Tools</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Email Signups</td>
+            <td>Grow Buttondown list with director&rsquo;s journals, mood reels, and production updates.</td>
+            <td><a href="https://buttondown.email/" target="_blank" rel="noopener">Buttondown</a></td>
+          </tr>
+          <tr>
+            <td>Donations</td>
+            <td>Invite contributions to bridge development expenses, location scouts, and lookbook shoots.</td>
+            <td><a href="https://buy.stripe.com/" target="_blank" rel="noopener">Stripe Checkout</a></td>
+          </tr>
+          <tr>
+            <td>Investor Meetings</td>
+            <td>Secure strategic conversations with financiers and producers through structured calendaring.</td>
+            <td><a href="https://cal.com/" target="_blank" rel="noopener">Cal.com</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="section section--overlay">
+      <div class="overline">Audience Alignment</div>
+      <h2>Communities primed for Golgotha.</h2>
+      <div class="grid two-column" style="margin-top:2.5rem;">
+        <div>
+          <ul class="list-soft">
+            <li>Tarkovsky fans who love horror</li>
+            <li>Followers of David Lynch&rsquo;s dreamlike investigations</li>
+            <li>Giallo enthusiasts seeking elevated dread</li>
+          </ul>
+        </div>
+        <div>
+          <ul class="list-soft">
+            <li>College-educated Millennials and Gen Z with an arts focus</li>
+            <li>Collectors of boutique physical media and limited editions</li>
+            <li>Visual artists, poets, photographers, and painters</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="overline">Disclaimer</div>
+      <p>Information on this page is for discussion purposes only and does not constitute a solicitation or offer to sell securities. Any investment opportunities will be presented separately and in accordance with applicable securities laws. Support through Stripe Checkout is a non-refundable donation that does not provide ownership or profit participation.</p>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/press.html
+++ b/press.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Press — Golgotha</title>
+  <meta name="description" content="Press and festival updates for the feature film Golgotha.">
+  <meta property="og:title" content="Press — Golgotha">
+  <meta property="og:description" content="Placeholder press information for Golgotha.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/press.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html" aria-current="page">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Press &amp; Festivals</div>
+        <h1>Building credibility before the spotlight.</h1>
+        <p>As Golgotha packages for financing, we&rsquo;re curating materials, critics, and festival strategies that align with elevated genre storytelling.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">Press Kit In Development</span>
+        <div class="poster-stack" tabindex="0" aria-label="Golgotha teaser posters">
+          <div class="poster-stack__poster poster-stack__poster--front">
+            <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross">
+          </div>
+          <div class="poster-stack__poster poster-stack__poster--back">
+            <img src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="status-panel">
+        <p class="caption">Current Status</p>
+        <strong>No press yet</strong>
+        <p>Press releases, festival submissions, and critic outreach are planned for post-packaging milestones. Media inquiries can be initiated through the contact page.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/public/poster-og-placeholder.svg
+++ b/public/poster-og-placeholder.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Golgotha Poster Placeholder</title>
+  <desc id="desc">Text-based placeholder for the Golgotha poster artwork.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0B0B0B" />
+      <stop offset="100%" stop-color="#1F0B0B" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <g fill="none" stroke="rgba(233,230,223,0.15)" stroke-width="1">
+    <path d="M0 70 H1200" />
+    <path d="M0 560 H1200" />
+    <path d="M120 0 V630" />
+    <path d="M1080 0 V630" />
+  </g>
+  <text x="50%" y="45%" fill="#E9E6DF" font-family="'Archivo Condensed', 'Arial Narrow', sans-serif" font-size="96" text-anchor="middle" letter-spacing="12" text-transform="uppercase">GOLGOTHA</text>
+  <text x="50%" y="60%" fill="#8B0F0F" font-family="'IBM Plex Mono', monospace" font-size="28" text-anchor="middle" letter-spacing="18" text-transform="uppercase">Poetic Horror - Noir Feature</text>
+</svg>

--- a/public/posters/golgotha-poster-1.svg
+++ b/public/posters/golgotha-poster-1.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="1.2" numOctaves="3" stitchTiles="stitch"/>
+      <feColorMatrix type="saturate" values="0"/>
+      <feComponentTransfer>
+        <feFuncA type="linear" slope="0.12"/>
+      </feComponentTransfer>
+    </filter>
+    <pattern id="fingerprint" patternUnits="userSpaceOnUse" width="140" height="140" patternTransform="rotate(8)">
+      <g fill="none" stroke="#0b0b0b" stroke-width="2">
+        <path d="M15 70c0-28 12-45 40-52 28-7 46 5 54 22 8 18 6 40-14 62-19 20-45 33-65 23C9 114 4 96 4 78c0-19 6-36 17-47" opacity="0.5"/>
+        <path d="M38 70c0-22 8-35 28-40 20-5 32 4 38 18s4 32-10 48c-14 15-33 25-48 17-14-7-18-21-18-35z" opacity="0.55"/>
+        <path d="M60 69c0-14 4-22 16-24 12-3 19 2 23 11 4 10 3 21-6 32-9 10-21 17-30 11-9-4-11-15-11-30z" opacity="0.6"/>
+      </g>
+    </pattern>
+  </defs>
+  <rect width="600" height="800" fill="#d9d7cf"/>
+  <rect width="600" height="800" fill="#d9d7cf" filter="url(#grain)" opacity="0.55"/>
+  <g transform="translate(0,0)">
+    <rect x="155" y="120" width="110" height="560" fill="url(#fingerprint)"/>
+    <rect x="155" y="120" width="110" height="560" fill="#0b0b0b" opacity="0.18"/>
+    <rect x="95" y="300" width="410" height="110" fill="url(#fingerprint)"/>
+    <rect x="95" y="300" width="410" height="110" fill="#0b0b0b" opacity="0.16"/>
+  </g>
+  <g fill="#0b0b0b" opacity="0.28">
+    <rect x="150" y="110" width="120" height="30"/>
+    <rect x="90" y="290" width="420" height="30"/>
+  </g>
+  <text x="58" y="118" font-family="'Archivo Black', 'Arial Black', sans-serif" font-size="72" letter-spacing="8" fill="#b50f0f">GOLGOTHA</text>
+  <g font-family="'IBM Plex Mono', 'Courier New', monospace" fill="#0b0b0b">
+    <text x="72" y="190" font-size="24" letter-spacing="12">A</text>
+    <text x="72" y="230" font-size="24" letter-spacing="8">MOTION</text>
+    <text x="72" y="270" font-size="24" letter-spacing="8">PICTURE</text>
+  </g>
+  <g font-family="'IBM Plex Mono', 'Courier New', monospace" fill="#0b0b0b" font-size="20" letter-spacing="6">
+    <text x="420" y="720">WINTER</text>
+    <text x="400" y="760">TWENTY-TWENTY-SIX</text>
+  </g>
+</svg>

--- a/public/posters/golgotha-poster-2.svg
+++ b/public/posters/golgotha-poster-2.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="glow" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#111"/>
+      <stop offset="100%" stop-color="#050505"/>
+    </linearGradient>
+    <filter id="noise" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="1.1" numOctaves="4"/>
+      <feComponentTransfer>
+        <feFuncR type="linear" slope="0.12"/>
+        <feFuncG type="linear" slope="0.12"/>
+        <feFuncB type="linear" slope="0.12"/>
+        <feFuncA type="linear" slope="0.05"/>
+      </feComponentTransfer>
+    </filter>
+    <linearGradient id="hand" x1="0.1" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f1f1f1"/>
+      <stop offset="55%" stop-color="#b7c7c7"/>
+      <stop offset="100%" stop-color="#4d5c5c"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" fill="url(#glow)"/>
+  <rect width="600" height="800" fill="#000" filter="url(#noise)" opacity="0.8"/>
+  <g transform="translate(100,120)">
+    <path d="M160 40c34 6 62 34 88 68 22 29 40 62 58 96 12 24 23 48 30 68 7 18 9 32 8 44-1 9-6 17-16 23-15 10-34 16-54 14-22-2-43-12-60-24-18-12-31-27-45-42-16-17-34-33-46-51-14-21-22-45-32-69-7-19-11-38-13-55-3-25 5-45 23-60 19-15 43-22 59-22z" fill="url(#hand)" stroke="#0b0b0b" stroke-width="6" stroke-linejoin="round" stroke-linecap="round" opacity="0.88"/>
+    <path d="M165 70c20 4 37 19 53 38 17 21 32 48 43 72 7 16 13 32 16 45 3 11 3 18-1 24-4 6-12 9-20 10-11 1-22-2-32-7-13-6-23-15-33-24-11-10-20-19-28-31-10-14-16-29-22-44-5-14-8-26-10-38-3-17 2-30 11-38 9-7 20-9 23-7z" fill="#050505" opacity="0.45"/>
+    <path d="M136 12c-24 4-46 16-62 32-18 18-26 40-26 66 0 23 6 49 15 74 9 25 20 51 34 74 13 21 28 39 46 56 20 19 40 37 64 50 22 12 46 20 69 21 23 1 46-6 64-19 12-9 22-22 24-36 3-21-4-44-12-63-11-27-23-53-37-78-17-30-35-61-57-86-23-26-50-48-82-59-15-4-30-6-40-4z" fill="none" stroke="#e9e6df" stroke-width="7" stroke-linecap="round" stroke-opacity="0.6" stroke-dasharray="12 16"/>
+  </g>
+  <text x="300" y="120" font-family="'IBM Plex Mono', 'Courier New', monospace" font-size="24" letter-spacing="12" fill="#e9e6df" text-anchor="middle">MOMMY LOVES YOU</text>
+  <g font-family="'IBM Plex Mono', 'Courier New', monospace" fill="#e9e6df" font-size="18" letter-spacing="4">
+    <text x="348" y="220">STARRING</text>
+    <text x="348" y="250">DANIEL OAKLEY</text>
+    <text x="348" y="290">AND</text>
+    <text x="348" y="320">MARIA LIMON</text>
+    <text x="348" y="370">WITH MUSIC BY</text>
+    <text x="348" y="400">GRANT CLAYTOR</text>
+    <text x="348" y="450">WRITTEN BY</text>
+    <text x="348" y="480">GRACE CURLEY</text>
+    <text x="348" y="530">PRODUCED BY</text>
+    <text x="348" y="560">ETHAN BELLER</text>
+    <text x="348" y="610">DIRECTED BY</text>
+    <text x="348" y="640">CHRISTOPHER ROSICA</text>
+  </g>
+  <text x="300" y="730" font-family="'Archivo Black', 'Arial Black', sans-serif" font-size="82" letter-spacing="8" fill="#b50f0f" text-anchor="middle">GOLGOTHA</text>
+  <text x="300" y="770" font-family="'IBM Plex Mono', 'Courier New', monospace" font-size="18" letter-spacing="6" fill="#e9e6df" text-anchor="middle">COLDBRICK PRESENTS</text>
+</svg>

--- a/public/team/christopher-rosica.svg
+++ b/public/team/christopher-rosica.svg
@@ -1,0 +1,20 @@
+<svg width="600" height="800" viewBox="0 0 600 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-cr" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#201010"/>
+      <stop offset="100%" stop-color="#3b1c1c"/>
+    </linearGradient>
+    <linearGradient id="gloss-cr" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(233,230,223,0.28)"/>
+      <stop offset="100%" stop-color="rgba(233,230,223,0)"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="600" height="800" rx="26" fill="url(#grad-cr)"/>
+  <rect x="28" y="42" width="544" height="716" rx="22" fill="#0F0F10" opacity="0.82"/>
+  <rect x="46" y="88" width="508" height="636" rx="18" fill="#1A1414"/>
+  <rect x="46" y="88" width="508" height="220" fill="url(#gloss-cr)" opacity="0.6"/>
+  <circle cx="300" cy="340" r="148" fill="#271919"/>
+  <circle cx="300" cy="330" r="108" fill="#312020"/>
+  <rect x="220" y="460" width="160" height="170" rx="70" fill="#362323"/>
+  <text x="300" y="715" font-family="'Archivo Black', 'Arial Black', sans-serif" font-size="64" fill="#E9E6DF" text-anchor="middle" letter-spacing="12">CR</text>
+</svg>

--- a/public/team/daniel-oakley.svg
+++ b/public/team/daniel-oakley.svg
@@ -1,0 +1,20 @@
+<svg width="600" height="800" viewBox="0 0 600 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-do" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#151c24"/>
+      <stop offset="100%" stop-color="#1b303c"/>
+    </linearGradient>
+    <linearGradient id="edge-do" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="rgba(233,230,223,0.12)"/>
+      <stop offset="100%" stop-color="rgba(233,230,223,0)"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="26" fill="url(#grad-do)"/>
+  <rect x="30" y="44" width="540" height="712" rx="24" fill="#060C10" opacity="0.92"/>
+  <rect x="50" y="92" width="500" height="632" rx="20" fill="#101820"/>
+  <rect x="50" y="92" width="80" height="632" fill="url(#edge-do)"/>
+  <circle cx="300" cy="310" r="140" fill="#142029"/>
+  <circle cx="300" cy="300" r="104" fill="#1F2E39"/>
+  <rect x="238" y="440" width="124" height="186" rx="60" fill="#253543"/>
+  <text x="300" y="712" font-family="'Archivo Black', 'Arial Black', sans-serif" font-size="60" fill="#E9E6DF" text-anchor="middle" letter-spacing="10">DO</text>
+</svg>

--- a/public/team/ethan-beller.svg
+++ b/public/team/ethan-beller.svg
@@ -1,0 +1,20 @@
+<svg width="600" height="800" viewBox="0 0 600 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-eb" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#21160f"/>
+      <stop offset="100%" stop-color="#3b2a1c"/>
+    </linearGradient>
+    <radialGradient id="sheen-eb" cx="0.5" cy="0.2" r="0.6">
+      <stop offset="0%" stop-color="rgba(233,230,223,0.2)"/>
+      <stop offset="100%" stop-color="rgba(233,230,223,0)"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="800" rx="26" fill="url(#grad-eb)"/>
+  <rect x="34" y="46" width="532" height="708" rx="24" fill="#110B07" opacity="0.9"/>
+  <rect x="54" y="94" width="492" height="628" rx="20" fill="#1B120C"/>
+  <rect x="54" y="94" width="492" height="240" fill="url(#sheen-eb)"/>
+  <ellipse cx="300" cy="320" rx="128" ry="136" fill="#2A1B10"/>
+  <ellipse cx="300" cy="312" rx="96" ry="108" fill="#362417"/>
+  <rect x="236" y="452" width="128" height="184" rx="62" fill="#3F2A19"/>
+  <text x="300" y="712" font-family="'Archivo Black', 'Arial Black', sans-serif" font-size="60" fill="#E9E6DF" text-anchor="middle" letter-spacing="10">EB</text>
+</svg>

--- a/public/team/faith-nicholas.svg
+++ b/public/team/faith-nicholas.svg
@@ -1,0 +1,20 @@
+<svg width="600" height="800" viewBox="0 0 600 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-fn" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a141a"/>
+      <stop offset="100%" stop-color="#2d1b2d"/>
+    </linearGradient>
+    <radialGradient id="veil-fn" cx="0.5" cy="0.25" r="0.65">
+      <stop offset="0%" stop-color="rgba(233,230,223,0.22)"/>
+      <stop offset="100%" stop-color="rgba(233,230,223,0)"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="800" rx="26" fill="url(#grad-fn)"/>
+  <rect x="36" y="50" width="528" height="700" rx="24" fill="#0A080A" opacity="0.94"/>
+  <rect x="56" y="98" width="488" height="620" rx="20" fill="#171017"/>
+  <rect x="56" y="98" width="488" height="260" fill="url(#veil-fn)"/>
+  <ellipse cx="300" cy="324" rx="130" ry="138" fill="#231222"/>
+  <ellipse cx="300" cy="316" rx="98" ry="110" fill="#31182F"/>
+  <rect x="236" y="456" width="128" height="180" rx="62" fill="#361C34"/>
+  <text x="300" y="712" font-family="'Archivo Black', 'Arial Black', sans-serif" font-size="60" fill="#E9E6DF" text-anchor="middle" letter-spacing="10">FN</text>
+</svg>

--- a/public/team/grace-caroline-curley.svg
+++ b/public/team/grace-caroline-curley.svg
@@ -1,0 +1,20 @@
+<svg width="600" height="800" viewBox="0 0 600 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-gc" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1b181f"/>
+      <stop offset="100%" stop-color="#301226"/>
+    </linearGradient>
+    <radialGradient id="halo-gc" cx="0.5" cy="0.3" r="0.7">
+      <stop offset="0%" stop-color="rgba(233,230,223,0.25)"/>
+      <stop offset="100%" stop-color="rgba(233,230,223,0)"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="800" rx="26" fill="url(#grad-gc)"/>
+  <rect x="32" y="48" width="536" height="704" rx="24" fill="#0C0B0D" opacity="0.88"/>
+  <rect x="52" y="96" width="496" height="624" rx="20" fill="#181016"/>
+  <rect x="52" y="96" width="496" height="320" fill="url(#halo-gc)"/>
+  <ellipse cx="300" cy="320" rx="136" ry="140" fill="#26141E"/>
+  <ellipse cx="300" cy="312" rx="100" ry="110" fill="#341B27"/>
+  <rect x="232" y="454" width="136" height="168" rx="64" fill="#3B1E2C"/>
+  <text x="300" y="712" font-family="'Archivo Black', 'Arial Black', sans-serif" font-size="60" fill="#E9E6DF" text-anchor="middle" letter-spacing="10">GCC</text>
+</svg>

--- a/screenings.html
+++ b/screenings.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Screenings — Golgotha</title>
+  <meta name="description" content="Screening announcements for the feature film Golgotha.">
+  <meta property="og:title" content="Screenings — Golgotha">
+  <meta property="og:description" content="Placeholder screening information for Golgotha.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/screenings.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html" aria-current="page">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Screenings</div>
+        <h1>Await the first communion.</h1>
+        <p>The premiere strategy targets genre festivals with prestige leanings, followed by bespoke event screenings that double as immersive rituals.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">Festival Run Pending</span>
+        <div class="poster-stack" tabindex="0" aria-label="Golgotha teaser posters">
+          <div class="poster-stack__poster poster-stack__poster--front">
+            <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross">
+          </div>
+          <div class="poster-stack__poster poster-stack__poster--back">
+            <img src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="status-panel">
+        <p class="caption">Current Status</p>
+        <strong>No screenings yet</strong>
+        <p>Dates will be announced once financing closes and production locks. Investors and press will receive first access via Buttondown.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/story.html
+++ b/story.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Story — Golgotha</title>
+  <meta name="description" content="Read the three-act synopsis of Golgotha, a poetic horror-noir feature film.">
+  <meta property="og:title" content="Story — Golgotha">
+  <meta property="og:description" content="Detective David Hill navigates grief, faith, and supernatural crimes in Golgotha.">
+  <meta property="og:image" content="/public/posters/golgotha-poster-1.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/story.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Condensed:wght@400;600&family=IBM+Plex+Mono:wght@300;400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="nav-container">
+      <a class="brand" href="index.html">Golgotha</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="story.html" aria-current="page">Story</a>
+        <a href="director.html">Director</a>
+        <a href="cast-crew.html">Cast &amp; Crew</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="press.html">Press</a>
+        <a href="screenings.html">Screenings</a>
+        <a href="investors.html">Investors</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section page-hero">
+      <div class="page-hero__content">
+        <div class="overline">Story</div>
+        <h1>An episodic descent into grief and apparition.</h1>
+        <p>The film unfolds in three investigations. Each chapter follows DAVID HILL as he confronts a murder, its spectral residue, and the way memory claws at the living. The film employs a threefold episodic structure&mdash;each section shows a murder and its investigation by our stoic protagonist.</p>
+      </div>
+      <div class="page-hero__meta">
+        <span class="badge badge--outline">Feature Narrative</span>
+        <div class="poster-stack" tabindex="0" aria-label="Golgotha teaser posters">
+          <div class="poster-stack__poster poster-stack__poster--front">
+            <img src="public/posters/golgotha-poster-1.svg" alt="Golgotha poster featuring a fingerprint cross">
+          </div>
+          <div class="poster-stack__poster poster-stack__poster--back">
+            <img src="public/posters/golgotha-poster-2.svg" alt="" aria-hidden="true">
+          </div>
+        </div>
+        <div class="status-panel">
+          <p class="caption">Running Themes</p>
+          <p>Resurrection myths, corrupted sacraments, and the cost of bargaining with the past.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tight">
+      <div class="grid cards" style="margin-top:3rem;">
+        <div class="card">
+          <p class="caption">I. The Tragedy of Belle &amp; Enzo</p>
+          <p>In a seedy motel on the outskirts of town, BELLE is murdered by her boyfriend, ENZO, for money. In her dying vision she sees a tender family reunion, dead relatives welcoming her home. DAVID solves the crime with ease and grows frustrated by its bleak normalcy. After a brief pursuit, ENZO is killed by police; his final vision is something vaguely human in a cheap tuxedo, its painted-on face drifting closer.</p>
+        </div>
+        <div class="card">
+          <p class="caption">II. The Strange Case of Norma Agnes Linwood</p>
+          <p>Jolted from a fevered nightmare, DAVID responds to NORMA, a middle-aged woman who cannot find her elderly mother. The decaying house mirrors his dream. NORMA is unkempt, terrified, and as the officers depart she stares at an upstairs window in pure horror. Alone, she tends to her mother&rsquo;s hidden, decaying body, applying makeup and brushing her hair each day. When NORMA calls to confess, she hallucinates TUXEDO MAN across from her, seizes, and is hospitalized. DAVID suspects mercy, not malice. Her last words before flatlining: &ldquo;Are you feeling better, mommy?&rdquo;</p>
+        </div>
+        <div class="card">
+          <p class="caption">III. David Goes Home</p>
+          <p>DAVID is called to 616 Freeman Avenue &mdash; the BURROW&rsquo;S House he believed burned down decades ago. In the yard rests his dead mother&rsquo;s severed hand, still as young as the day she died thirty years earlier. He steps inside without hesitation, following bloody handprints lining the hall toward a closed door that promises a revelation beyond imagination.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">&copy; Golgotha Film. All rights reserved.</div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate new SVG key art for Golgotha and animate the homepage hero poster to flip between both designs
- surface the posters across interior page heroes, update Open Graph previews, and add a reusable poster stack treatment
- feature both posters inside the gallery alongside the still placeholders with supporting layout and style refinements

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d9f12573c48331887782f9cfb0d6b9