### PR TITLE
Document Open Graph placeholder usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ python3 -m http.server 8000
 ```
 
 Then visit `http://localhost:8000/`.
+
+To verify the Open Graph placeholder renders, open `http://localhost:8000/public/poster-og-placeholder.svg` in a browser; the text-based poster should display crisply inlined against a dark background.

--- a/cast-crew.html
+++ b/cast-crew.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Meet the cast and crew assembling the feature film Golgotha.">
   <meta property="og:title" content="Cast &amp; Crew — Golgotha">
   <meta property="og:description" content="Placeholder bios for the cast and crew of Golgotha.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/cast-crew.html">

--- a/contact.html
+++ b/contact.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Contact the Golgotha team for partnerships, press, and support.">
   <meta property="og:title" content="Contact — Golgotha">
   <meta property="og:description" content="Reach the Golgotha team for investor calls, press, and collaborations.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/contact.html">

--- a/director.html
+++ b/director.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Director's statement for Golgotha, a poetic horror-noir feature film.">
   <meta property="og:title" content="Director — Golgotha">
   <meta property="og:description" content="The director of Golgotha treats horror as poetry, orchestrating grief, faith, and memory.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/director.html">

--- a/gallery.html
+++ b/gallery.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Placeholder stills for the feature film Golgotha.">
   <meta property="og:title" content="Gallery — Golgotha">
   <meta property="og:description" content="Explore twelve placeholder stills capturing Golgotha&rsquo;s mood.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/gallery.html">

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="DAVID HILL, a jaded detective, wrestles with existential angst while investigating surreal and supernatural crimes.">
   <meta property="og:title" content="Golgotha — Poetic Horror-Noir Feature Film">
   <meta property="og:description" content="DAVID HILL, a jaded detective, wrestles with existential angst while investigating surreal and supernatural crimes.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/">

--- a/investors.html
+++ b/investors.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Investor overview for the feature film Golgotha.">
   <meta property="og:title" content="Investors — Golgotha">
   <meta property="og:description" content="Review the investor overview, deck request, and support options for Golgotha.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/investors.html">

--- a/press.html
+++ b/press.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Press and festival updates for the feature film Golgotha.">
   <meta property="og:title" content="Press — Golgotha">
   <meta property="og:description" content="Placeholder press information for Golgotha.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/press.html">

--- a/screenings.html
+++ b/screenings.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Screening announcements for the feature film Golgotha.">
   <meta property="og:title" content="Screenings — Golgotha">
   <meta property="og:description" content="Placeholder screening information for Golgotha.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/screenings.html">

--- a/story.html
+++ b/story.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Read the three-act synopsis of Golgotha, a poetic horror-noir feature film.">
   <meta property="og:title" content="Story — Golgotha">
   <meta property="og:description" content="Detective David Hill navigates grief, faith, and supernatural crimes in Golgotha.">
+  <!-- Open Graph image placeholder until final poster art is ready -->
   <meta property="og:image" content="/public/poster-og-placeholder.svg">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://example.com/story.html">


### PR DESCRIPTION
## Summary
- annotate every HTML entry point to clarify that the Open Graph image is a temporary poster placeholder
- add README instructions for previewing the placeholder asset when running the static server locally

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68da04be13fc8331b1f9ff55dda82350