### PR TITLE
Remove poster artwork references from site

### DIFF
--- a/cast-crew.html
+++ b/cast-crew.html
@@ -106,7 +106,7 @@
       <div class="team-grid" style="margin-top:3rem;">
         <article class="profile-card">
           <div class="profile-card__portrait">
-            <img src="assets/portraits/christopher-rosica.svg" alt="Illustrated portrait of Christopher Rosica">
+            <div class="profile-card__placeholder" role="img" aria-label="Illustrated portrait of Christopher Rosica currently unavailable."></div>
           </div>
           <div class="profile-card__body">
             <p class="profile-card__role">Director</p>
@@ -117,7 +117,7 @@
         </article>
         <article class="profile-card">
           <div class="profile-card__portrait">
-            <img src="assets/portraits/grace-caroline-curley.svg" alt="Illustrated portrait of Grace Caroline Curley">
+            <div class="profile-card__placeholder" role="img" aria-label="Illustrated portrait of Grace Caroline Curley currently unavailable."></div>
           </div>
           <div class="profile-card__body">
             <p class="profile-card__role">Screenwriter</p>
@@ -128,7 +128,7 @@
         </article>
         <article class="profile-card">
           <div class="profile-card__portrait">
-            <img src="assets/portraits/daniel-oakley.svg" alt="Illustrated portrait of Daniel Oakley">
+            <div class="profile-card__placeholder" role="img" aria-label="Illustrated portrait of Daniel Oakley currently unavailable."></div>
           </div>
           <div class="profile-card__body">
             <p class="profile-card__role">Lead Actor</p>
@@ -139,7 +139,7 @@
         </article>
         <article class="profile-card">
           <div class="profile-card__portrait">
-            <img src="assets/portraits/ethan-beller.svg" alt="Illustrated portrait of Ethan Beller">
+            <div class="profile-card__placeholder" role="img" aria-label="Illustrated portrait of Ethan Beller currently unavailable."></div>
           </div>
           <div class="profile-card__body">
             <p class="profile-card__role">Lead Producer</p>
@@ -150,7 +150,7 @@
         </article>
         <article class="profile-card">
           <div class="profile-card__portrait">
-            <img src="assets/portraits/faith-nicholas.svg" alt="Illustrated portrait of Faith Nicholas">
+            <div class="profile-card__placeholder" role="img" aria-label="Illustrated portrait of Faith Nicholas currently unavailable."></div>
           </div>
           <div class="profile-card__body">
             <p class="profile-card__role">Casting Director</p>

--- a/gallery.html
+++ b/gallery.html
@@ -57,11 +57,11 @@
     <section class="section section--tight">
       <div class="gallery-grid">
         <figure class="gallery-item gallery-item--poster">
-          <img src="public/golgotha-poster-mother.svg" alt="Golgotha poster reading Mommy Loves You, featuring a skeletal hand emerging from darkness and red Golgotha title treatment.">
+          <div class="gallery-item__note" role="img" aria-label="Textual description of the Mommy Loves You poster concept featuring a skeletal hand emerging from darkness and the Golgotha title treatment."></div>
           <figcaption>Poster 01 &mdash; Mommy Loves You</figcaption>
         </figure>
         <figure class="gallery-item gallery-item--poster">
-          <img src="public/golgotha-poster-relic.svg" alt="Golgotha poster featuring fingerprint impressions forming a cross blueprint.">
+          <div class="gallery-item__note" role="img" aria-label="Textual description of the Relic Index poster concept depicting fingerprint impressions forming a cross blueprint."></div>
           <figcaption>Poster 02 &mdash; Relic Index</figcaption>
         </figure>
         <div class="gallery-item"><span>Still 01 &mdash; Alley of Echoes</span></div>

--- a/index.html
+++ b/index.html
@@ -53,18 +53,19 @@
       </div>
       <div class="hero-media">
         <div class="hero-frame hero-frame--flip">
-          <div class="poster-flip" tabindex="0" aria-label="Flip between the two Golgotha posters" aria-describedby="poster-instruction">
-            <figure class="poster-face poster-face--front">
-              <img src="public/golgotha-poster-mother.svg" alt="Golgotha poster reading Mommy Loves You with a bone-white hand reaching from the dark and red Golgotha title at the base.">
-              <figcaption>Poster I &mdash; Mommy Loves You</figcaption>
-            </figure>
-            <figure class="poster-face poster-face--back">
-              <img src="public/golgotha-poster-relic.svg" alt="Golgotha key art featuring fingerprint impressions forming a cruciform blueprint.">
-              <figcaption>Poster II &mdash; Relic Index</figcaption>
-            </figure>
+          <div class="poster-summary" aria-label="Summary of Golgotha poster concepts">
+            <div class="poster-summary__item">
+              <p class="caption">Poster Concept I</p>
+              <h3>Mommy Loves You</h3>
+              <p>A bone-white hand emerging from darkness, the Golgotha title pulsing at the base in blood red.</p>
+            </div>
+            <div class="poster-summary__item">
+              <p class="caption">Poster Concept II</p>
+              <h3>Relic Index</h3>
+              <p>Fingerprint impressions interlocking into a cruciform blueprint, suggesting relics catalogued in shadow.</p>
+            </div>
           </div>
         </div>
-        <p class="hero-instruction" id="poster-instruction">Hover or focus to reveal both posters.</p>
         <div class="status-panel">
           <p class="caption">Investment Hooks</p>
           <strong>Elevated horror noir</strong>


### PR DESCRIPTION
## Summary
- replace the landing page poster flip component with text descriptions of each concept
- swap cast and crew portrait images for accessible placeholders that indicate art is unavailable
- convert gallery poster entries to text-only notes so no images are rendered

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68dabfc0cf248331a23fe7320f3f1815